### PR TITLE
Auto-name agents with themed batch add

### DIFF
--- a/src/renderer/src/components/spec/AgentRow.tsx
+++ b/src/renderer/src/components/spec/AgentRow.tsx
@@ -2,6 +2,7 @@
 // FEATURE: Agent editor component using inline expand pattern for dense layout
 import { useState } from 'react'
 import type { AgentSpec } from '../../../../shared/types'
+import { deriveSlug } from '../../../../shared/slug'
 
 interface Props {
   agent: AgentSpec
@@ -10,9 +11,6 @@ interface Props {
   onChange: (updated: AgentSpec) => void
   onDelete: () => void
 }
-
-const toAgentSlug = (name: string) =>
-  name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 
 const fieldRow = (label: string, value: string, onChange: (v: string) => void, opts?: { mono?: boolean; multiline?: boolean; placeholder?: string }) => (
   <div className="flex items-start gap-2">
@@ -42,7 +40,7 @@ export function AgentRow({ agent, isFirst, providerSlugs, onChange, onDelete }: 
   const set = (key: keyof AgentSpec) => (value: unknown) => onChange({ ...agent, [key]: value })
 
   const handleNameChange = (name: string) => {
-    onChange({ ...agent, name, slug: name ? toAgentSlug(name) : '' })
+    onChange({ ...agent, name, slug: name ? deriveSlug(name) : '' })
   }
 
   return (

--- a/src/renderer/src/components/spec/SpecForm.tsx
+++ b/src/renderer/src/components/spec/SpecForm.tsx
@@ -1,10 +1,11 @@
 // Structured form for editing team spec fields inline without dialogs
 // FEATURE: Team spec editor left panel with agents list and inline field editing
-import { useCallback } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useSaveTeam } from '../../hooks/useTeams'
 import { useProviders } from '../../hooks/useProviders'
 import { AgentRow } from './AgentRow'
 import type { TeamSpec, AgentSpec } from '../../../../shared/types'
+import { generateAutoAgentIdentities, type AgentNameTheme } from '../../../../shared/agentNames'
 
 interface Props {
   spec: TeamSpec
@@ -13,32 +14,56 @@ interface Props {
 
 const inputCls = 'bg-gray-800 border border-gray-700 rounded px-1.5 py-0.5 text-[11px] text-gray-200 focus:outline-none focus:border-blue-600 w-full font-mono'
 const labelCls = 'text-[10px] text-gray-500 block mb-0.5'
+const nameThemeOptions: Array<{ value: AgentNameTheme; label: string }> = [
+  { value: 'sci-fi', label: 'Sci-Fi' },
+  { value: 'movies', label: 'Movies' },
+  { value: 'mixed', label: 'Mixed' }
+]
 
 export function SpecForm({ spec, onSpecChange }: Props) {
   const saveTeam = useSaveTeam()
   const { data: providers } = useProviders()
   const providerSlugs = (providers ?? []).map(p => p.slug)
+  const [nameTheme, setNameTheme] = useState<AgentNameTheme>('sci-fi')
 
   const set = useCallback((key: keyof TeamSpec) => (value: unknown) => {
     onSpecChange({ ...spec, [key]: value })
   }, [spec, onSpecChange])
 
-  const addAgent = () => {
-    const newAgent: AgentSpec = { slug: '', name: '', role: '', providerSlug: '', skills: [], soul: '', isLead: spec.agents.length === 0 }
-    onSpecChange({ ...spec, agents: [...spec.agents, newAgent] })
+  const applyAgents = (agents: AgentSpec[]) => {
+    const normalized = agents.map((agent, i) => ({ ...agent, isLead: i === 0 }))
+    onSpecChange({ ...spec, agents: normalized, leadAgentSlug: normalized[0]?.slug || undefined })
+  }
+
+  const addAutoAgents = (count: number) => {
+    const generated = generateAutoAgentIdentities(spec.agents, count, nameTheme)
+    if (!generated.length) return
+
+    const newAgents: AgentSpec[] = generated.map((identity) => ({
+      slug: identity.slug,
+      name: identity.name,
+      role: '',
+      providerSlug: '',
+      skills: [],
+      soul: '',
+      isLead: false
+    }))
+
+    applyAgents([...spec.agents, ...newAgents])
   }
 
   const updateAgent = (i: number, updated: AgentSpec) => {
     const agents = [...spec.agents]
-    agents[i] = { ...updated, isLead: i === 0 }
-    onSpecChange({ ...spec, agents, leadAgentSlug: agents[0]?.slug || spec.leadAgentSlug })
+    agents[i] = updated
+    applyAgents(agents)
   }
 
   const deleteAgent = (i: number) => {
-    onSpecChange({ ...spec, agents: spec.agents.filter((_, j) => j !== i) })
+    applyAgents(spec.agents.filter((_, j) => j !== i))
   }
 
   const handleSave = () => saveTeam.mutate(spec)
+  const [nextAutoName] = useMemo(() => generateAutoAgentIdentities(spec.agents, 1, nameTheme), [spec.agents, nameTheme])
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
@@ -100,9 +125,46 @@ export function SpecForm({ spec, onSpecChange }: Props) {
         </div>
 
         <div>
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-[10px] text-gray-500 uppercase tracking-wider">Agents ({spec.agents.length})</span>
-            <button onClick={addAgent} className="text-[10px] text-blue-500 hover:text-blue-400">+ add</button>
+          <div className="mb-1.5 space-y-1.5">
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] text-gray-500 uppercase tracking-wider">Agents ({spec.agents.length})</span>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => addAutoAgents(1)}
+                  className="text-[10px] px-1.5 py-0.5 rounded border border-blue-600/60 text-blue-300 hover:border-blue-500 hover:text-blue-200 transition-colors"
+                >
+                  +1 auto
+                </button>
+                <button
+                  onClick={() => addAutoAgents(10)}
+                  className="text-[10px] px-1.5 py-0.5 rounded border border-blue-600/60 text-blue-300 hover:border-blue-500 hover:text-blue-200 transition-colors"
+                >
+                  +10 auto
+                </button>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] text-gray-600">name pack</span>
+              <div role="tablist" aria-label="Agent name pack" className="inline-flex rounded-md border border-gray-700 bg-gray-900/40 p-0.5">
+                {nameThemeOptions.map((option) => {
+                  const active = nameTheme === option.value
+                  return (
+                    <button
+                      key={option.value}
+                      role="tab"
+                      aria-selected={active}
+                      onClick={() => setNameTheme(option.value)}
+                      className={`text-[10px] px-2 py-0.5 rounded transition-colors ${active ? 'bg-gray-700 text-gray-100' : 'text-gray-500 hover:text-gray-300'}`}
+                    >
+                      {option.label}
+                    </button>
+                  )
+                })}
+              </div>
+              {nextAutoName && (
+                <span className="text-[10px] text-gray-600 truncate">next: {nextAutoName.name}</span>
+              )}
+            </div>
           </div>
           <div className="space-y-1">
             {spec.agents.map((agent, i) => (

--- a/src/shared/agentNames.test.ts
+++ b/src/shared/agentNames.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  generateAutoAgentIdentities,
+  SCI_FI_AGENT_NAMES,
+  type ExistingAgentIdentity
+} from './agentNames'
+
+describe('generateAutoAgentIdentities', () => {
+  it('uses the selected theme pool', () => {
+    const [first] = generateAutoAgentIdentities([], 1, 'sci-fi')
+    expect(first).toEqual({ name: 'Ripley', slug: 'ripley' })
+  })
+
+  it('uses variants once a name pool is exhausted', () => {
+    const existingAgents: ExistingAgentIdentity[] = SCI_FI_AGENT_NAMES.map((name) => ({
+      name,
+      slug: name.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+    }))
+
+    const [next] = generateAutoAgentIdentities(existingAgents, 1, 'sci-fi')
+    expect(next.name).toBe('Ripley Prime')
+    expect(next.slug).toBe('ripley-prime')
+  })
+
+  it('keeps generated slugs unique', () => {
+    const [first] = generateAutoAgentIdentities([{ slug: 'ripley' }], 1, 'sci-fi')
+    expect(first.slug).toBe('ripley-2')
+  })
+
+  it('generates multiple unique identities for batch add', () => {
+    const generated = generateAutoAgentIdentities([], 10, 'mixed')
+    expect(generated).toHaveLength(10)
+
+    const names = new Set(generated.map((agent) => agent.name.toLowerCase()))
+    const slugs = new Set(generated.map((agent) => agent.slug))
+
+    expect(names.size).toBe(10)
+    expect(slugs.size).toBe(10)
+  })
+})

--- a/src/shared/agentNames.ts
+++ b/src/shared/agentNames.ts
@@ -1,0 +1,125 @@
+import { deriveSlug } from './slug'
+
+export type AgentNameTheme = 'sci-fi' | 'movies' | 'mixed'
+
+export interface AgentIdentity {
+  name: string
+  slug: string
+}
+
+export interface ExistingAgentIdentity {
+  name?: string
+  slug?: string
+}
+
+export const SCI_FI_AGENT_NAMES = [
+  'Ripley',
+  'Deckard',
+  'Leeloo',
+  'Neo',
+  'Trinity',
+  'Spock',
+  'Uhura',
+  'Data',
+  'TARS',
+  'Motoko',
+  'Kara Thrace',
+  'River',
+  'Aeryn',
+  'Riker',
+  'Seven',
+  'Korben',
+  'Kaylee',
+  'Andromeda',
+  'Garrus',
+  'Jadzia'
+] as const
+
+export const MOVIE_AGENT_NAMES = [
+  'Maverick',
+  'Furiosa',
+  'Aragorn',
+  'Indiana',
+  'Mulan',
+  'Katniss',
+  'Hermione',
+  'Maximus',
+  'Amelie',
+  'Clarice',
+  'Moana',
+  'Elsa',
+  'Bond',
+  'Rocky',
+  'Vito',
+  'Wallace',
+  'Chihiro',
+  'Bourne',
+  'Padme',
+  'Arthur Fleck'
+] as const
+
+const NAME_VARIANTS = ['Prime', 'Nova', 'Echo', 'Vector', 'Comet', 'Cipher', 'Atlas', 'Drift'] as const
+
+const normalize = (value: string): string => value.trim().toLowerCase()
+
+const namePoolForTheme = (theme: AgentNameTheme): readonly string[] => {
+  if (theme === 'sci-fi') return SCI_FI_AGENT_NAMES
+  if (theme === 'movies') return MOVIE_AGENT_NAMES
+  return [...SCI_FI_AGENT_NAMES, ...MOVIE_AGENT_NAMES]
+}
+
+const chooseUniqueName = (pool: readonly string[], usedNames: Set<string>): string => {
+  for (const baseName of pool) {
+    if (!usedNames.has(normalize(baseName))) return baseName
+  }
+
+  for (const variant of NAME_VARIANTS) {
+    for (const baseName of pool) {
+      const candidate = `${baseName} ${variant}`
+      if (!usedNames.has(normalize(candidate))) return candidate
+    }
+  }
+
+  let counter = 2
+  while (true) {
+    for (const baseName of pool) {
+      const candidate = `${baseName} ${counter}`
+      if (!usedNames.has(normalize(candidate))) return candidate
+    }
+    counter += 1
+  }
+}
+
+const chooseUniqueSlug = (slugBase: string, usedSlugs: Set<string>): string => {
+  const base = slugBase || 'agent'
+  if (!usedSlugs.has(base)) return base
+
+  let counter = 2
+  while (usedSlugs.has(`${base}-${counter}`)) counter += 1
+  return `${base}-${counter}`
+}
+
+export function generateAutoAgentIdentities(
+  existingAgents: ExistingAgentIdentity[],
+  count: number,
+  theme: AgentNameTheme
+): AgentIdentity[] {
+  if (count <= 0) return []
+
+  const usedNames = new Set(existingAgents.map((agent) => normalize(agent.name ?? '')).filter(Boolean))
+  const usedSlugs = new Set(existingAgents.map((agent) => normalize(agent.slug ?? '')).filter(Boolean))
+  const pool = namePoolForTheme(theme)
+  const generated: AgentIdentity[] = []
+
+  for (let i = 0; i < count; i += 1) {
+    const name = chooseUniqueName(pool, usedNames)
+    usedNames.add(normalize(name))
+
+    const slug = chooseUniqueSlug(deriveSlug(name), usedSlugs)
+    usedSlugs.add(slug)
+
+    generated.push({ name, slug })
+  }
+
+  return generated
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,6 +19,7 @@ export interface TeamSpec {
   name: string
   domain?: string
   image?: string
+  storageGi?: number
   leadAgentSlug?: string
   bootstrapInstructions?: string
   tokenSeed?: string


### PR DESCRIPTION
This PR adds automatic agent naming so users can create agents without manually entering names. It introduces shared name generation with sci-fi, movie, and mixed pools plus unique slug handling and fallback variants for large batches. The team spec form now supports +1 auto and +10 auto creation, name-pack selection, next-name preview, and lead-agent normalization when agents are added, edited, or removed. It also aligns AgentRow slug generation with shared deriveSlug and adds TeamSpec.storageGi to match existing UI usage. Generator tests were added for theme selection, pool exhaustion, slug uniqueness, and batch generation.