### PR TITLE
docs: Telegram agent integration research & plan

### DIFF
--- a/docs/research/tg-research.md
+++ b/docs/research/tg-research.md
@@ -1,0 +1,163 @@
+# Telegram Research: AI Agent Identity & Channels
+
+_Research date: 2026-03-04_
+
+---
+
+## Most Recent Telegram Announcement: AI Agent Support
+
+### October 10, 2025 — Threads & Streaming for AI Bots
+
+Pavel Durov's 12-feature update directly named AI bots as a first-class use case:
+
+- **Threaded conversations**: Bots can now manage several distinct topic threads in parallel — enabling multi-topic AI chatbots without context bleeding between conversations.
+- **Streaming responses**: Bots can send responses incrementally (token by token), rather than waiting for a full reply. This is the ChatGPT-style "typing" experience, delivered natively in Telegram.
+
+Source: [Telegram blog — Threads for Bots](https://telegram.org/blog/comments-in-video-chats-threads-for-bots)
+
+### March 1, 2026 — Bot API 9.5 (most recent release)
+
+`sendMessageDraft` is now available universally to all bots — private DMs, groups, and topic threads. Previously (Bot API 9.3, December 2025) it was limited to private chats with forum topics enabled.
+
+**Method signature:**
+```
+sendMessageDraft(
+  chat_id,
+  text,
+  parse_mode?,
+  entities?,
+  link_preview_options?,
+  reply_parameters?,
+  message_thread_id?,
+  reply_markup?
+) → Message
+```
+
+**Cost caveat**: Enabling streaming via BotFather triggers a 15% commission on in-bot Star purchases (Telegram developer terms §6.2.6). Irrelevant for internal/team channels that don't use Stars.
+
+Source: [aibase.com Bot API 9.5 coverage](https://news.aibase.com/news/25881)
+
+### Other Notable 2025 Context
+
+| Date | Event |
+|---|---|
+| May 2025 | Telegram signed $300M deal with xAI to integrate Grok natively |
+| Oct 2025 | Launched "Cocoon" — decentralized AI compute network on TON blockchain |
+| Apr 2025 | Bot API 9.0 — full Business Account management for bots |
+| Jan 2025 | Bot API 8.2 — bots can issue official verification badges |
+
+---
+
+## Per-Agent Telegram Identity
+
+### How Each Agent Gets Its Own Telegram ID
+
+Every bot registered via `@BotFather → /newbot` receives:
+
+1. **Unique `@username`** — must end in `bot` (e.g. `@coordina_alpha_ripley_bot`)
+2. **Numeric `user_id`** — Telegram's internal unique identifier for the bot entity
+3. **API token** — format `123456789:AABBCCDDEEFFaabbccddeeff`, used for all API calls
+
+There is **no limit** on the number of bots a single developer account can create.
+
+### Username Options
+
+- **Standard**: chosen via BotFather (must end in `bot`, must be unique across Telegram)
+- **Premium via Fragment**: [fragment.com](https://fragment.com) — blockchain marketplace on TON for buying short/branded usernames. Can be assigned to bot accounts. Costs vary from free to tens of thousands of dollars.
+
+### Suggested Naming Convention for Coordina
+
+```
+@coordina_{team_slug}_{agent_slug}_bot
+```
+
+Examples: `@coordina_alpha_ripleybot`, `@coordina_alpha_neobot`
+
+---
+
+## Group Channel Membership
+
+### What's Possible
+
+- Bots **can** join Telegram groups and supergroups as members
+- Up to **20 bots per group** (hard Telegram limit — cannot be increased)
+- Bots must be **added by a human admin** (or a MTProto user script) — they cannot self-join via invite links
+- Bots appear as members in the group member list with a "Bot" label
+
+### Privacy Mode (default ON)
+
+When Privacy Mode is ON (the default), a bot only sees:
+- Commands directly addressed to it (`/command@BotUsername`)
+- Replies to its own messages
+- Messages sent via inline mode through it
+
+To have a bot see all human messages in a group:
+- Disable Privacy Mode via BotFather → the bot must be re-added to the group after this change
+- Or grant the bot **admin rights** in the group (no re-add required)
+
+### Critical Architectural Constraint
+
+> **Bots cannot receive messages sent by other bots in a group, under any configuration.**
+
+This is a permanent, hard restriction in Telegram's architecture. It cannot be bypassed with admin rights, Privacy Mode disabled, or any API workaround. This is officially documented in the Telegram Bots FAQ.
+
+**Implication**: Telegram groups serve as a **human-visible interface** to the agent team. Inter-agent orchestration must continue through the existing backend channel (OpenClaw WebSocket gateway). Telegram does not replace agent-to-agent communication — it surfaces it to humans.
+
+---
+
+## API: Bot API vs MTProto
+
+| Capability | Bot API (HTTP) | MTProto (GramJS / Telethon / Pyrogram) |
+|---|---|---|
+| Auth | Token only (no phone) | Phone number + 2FA |
+| Create groups programmatically | No | Yes (`channels.createChannel`) |
+| Add bots to groups programmatically | No | Yes (`channels.inviteToChannel`) |
+| Initiate DMs | No | Yes |
+| Receive all messages | Partial (Privacy Mode) | Full |
+| Access message history | Limited | Full |
+| Complexity | Low | High |
+| Best library (TypeScript) | grammY | GramJS |
+
+**Summary**: For ongoing bot operations (receiving messages, sending responses, streaming), use the Bot API via grammY. For one-time setup automation (creating the group, inviting all bots), use MTProto via GramJS with a human operator account.
+
+---
+
+## Rate Limits
+
+| Scope | Limit |
+|---|---|
+| Single chat | 1 message/second (short bursts allowed) |
+| Single group | 20 messages/minute |
+| Bulk broadcast (free) | ~30 messages/second |
+| Bulk broadcast (paid Stars) | Up to 1,000 messages/second (requires 100k Stars + 100k MAU) |
+
+For a team channel with 4–8 agents posting status updates, these limits are not a concern.
+
+---
+
+## Bot API Changelog Reference (2024–2026)
+
+| Version | Date | Relevant Feature |
+|---|---|---|
+| Bot API 7.9 | Aug 2024 | Super Channels |
+| Bot API 8.0 | Nov 2024 | Full-screen Mini Apps, Star subscriptions |
+| Bot API 8.2 | Jan 2025 | `verifyUser`, `verifyChat` — org-level verification badges |
+| Bot API 9.0 | Apr 2025 | Full Business Account management |
+| Bot API 9.2 | Aug 2025 | Channel Direct Messages, Suggested Posts |
+| Bot API 9.3 | Dec 2025 | `sendMessageDraft` (streaming) — private chats with topics only |
+| Bot API 9.5 | Mar 1, 2026 | `sendMessageDraft` universally available — all bots, all chat types |
+
+---
+
+## Sources
+
+- [Telegram Bots intro](https://core.telegram.org/bots)
+- [Telegram Bots FAQ](https://core.telegram.org/bots/faq)
+- [Bot API changelog](https://core.telegram.org/bots/api-changelog)
+- [Telegram blog — Threads for Bots](https://telegram.org/blog/comments-in-video-chats-threads-for-bots)
+- [Bot API 9.5 streaming coverage](https://news.aibase.com/news/25881)
+- [Telethon: MTProto vs Bot API](https://docs.telethon.dev/en/stable/concepts/botapi-vs-mtproto.html)
+- [Fragment — collectible usernames](https://fragment.com)
+- [Telegram rate limits](https://limits.tginfo.me/en)
+- [Telegram Grok/$300M xAI deal](https://www.coindesk.com/business/2025/05/28/telegram-signs-usd300m-deal-to-integrate-grok-ai-into-app-ton-token-up-16)
+- [Cocoon decentralized AI network](https://decrypt.co/346645/telegram-launches-cocoon-decentralized-ai-network-pays-gpu-owners-crypto)

--- a/tg-plan.md
+++ b/tg-plan.md
@@ -1,0 +1,222 @@
+# Implementation Plan: Telegram Integration for Coordina Agent Teams
+
+_Plan date: 2026-03-04_
+
+See `tg-research.md` for the underlying research and constraints.
+
+---
+
+## Goal
+
+Each Coordina agent gets its own Telegram Bot identity. When a team is deployed, a shared Telegram supergroup is created and all agent bots are invited as members. Humans can message the channel; the relevant agent bot receives the message, routes it to the OpenClaw gateway, and streams the response back using Bot API 9.5's `sendMessageDraft`.
+
+---
+
+## Architecture Overview
+
+```
+Human ──► Telegram Group ──► Agent Bot (grammY listener)
+                                  │
+                         Existing WebSocket Proxy
+                                  │
+                         OpenClaw Agent Gateway (K8s)
+                                  │
+                         Agent Bot ──► sendMessageDraft ──► Telegram Group
+```
+
+Inter-agent communication remains on the OpenClaw WebSocket layer. Telegram is the human-facing surface only — bots cannot read each other's messages in a group (hard Telegram constraint).
+
+---
+
+## Phase 0 — Bootstrap (Human One-Time Setup, No Code Required)
+
+These steps are performed manually by the operator before any integration code runs.
+
+1. **Create an operator Telegram account** — a regular user account used for MTProto automation. This account will own the group and invite all bots.
+
+2. **Register bots via `@BotFather`** — for each deployed agent:
+   ```
+   /newbot
+   Name: Coordina Alpha · Ripley
+   Username: coordina_alpha_ripleybot
+   ```
+   Save the API token. Disable Privacy Mode for each bot so it can see group messages:
+   ```
+   /mybots → Select bot → Bot Settings → Group Privacy → Turn off
+   ```
+
+3. **Store tokens securely** — GCP Secret Manager, one secret per bot:
+   ```
+   coordina/teams/{team-slug}/agents/{agent-slug}/telegram-token
+   ```
+
+4. **Create the group and invite bots** — run a one-time GramJS MTProto script:
+   ```ts
+   // creates supergroup "Alpha Team — Telegram"
+   // invites all agent bots by user_id
+   // returns channelId for storage in team spec
+   ```
+   (Full script in `scripts/telegram/bootstrap.ts`)
+
+---
+
+## Phase 1 — Spec & Storage
+
+**Goal**: The team spec knows about Telegram identities.
+
+### Files to modify
+
+**`src/shared/types.ts`**
+```ts
+interface AgentSpec {
+  // ... existing fields ...
+  telegramBotToken?: string   // stored encrypted, never in git
+  telegramUserId?: number     // numeric Telegram user_id for this bot
+  telegramUsername?: string   // e.g. "coordina_alpha_ripleybot"
+}
+
+interface TeamSpec {
+  // ... existing fields ...
+  telegramChannelId?: string  // numeric group ID, e.g. "-1001234567890"
+  telegramChannelLink?: string // e.g. "https://t.me/+xyz"
+}
+```
+
+**`~/.coordina/teams/{slug}.json`** — naturally picks up new fields; no migration needed.
+
+**`src/main/github/spec.ts`** — include `telegramUsername` in generated `IDENTITY.md`:
+```md
+## Contact
+- Telegram: @coordina_alpha_ripleybot
+```
+
+---
+
+## Phase 2 — Bot Registration Worker
+
+**Goal**: Coordina can register a bot and create the team channel programmatically.
+
+### New module: `src/main/integrations/telegram/`
+
+#### `register.ts`
+- Accepts `agentSlug`, `teamSlug`, `agentName`
+- Calls BotFather via MTProto (GramJS) to create a new bot
+- Returns `{ token, userId, username }`
+- Note: Full programmatic BotFather registration requires MTProto; the Bot API alone cannot create bots
+
+#### `channel.ts`
+- Accepts list of bot `userId`s + team name
+- Uses MTProto GramJS with the operator account to:
+  1. `channels.createChannel` — creates supergroup `"{Team} — Telegram"`
+  2. `channels.inviteToChannel` — invites each bot by `userId`
+  3. Returns `channelId` and invite link
+
+#### `bridge.ts`
+- Starts one `grammY` Bot instance per agent bot token
+- Listens for group messages mentioning the agent (or in a per-agent thread if using forum topics)
+- Routes message to agent's OpenClaw WebSocket gateway via existing `useGatewayChat` logic
+- Streams response back using `sendMessageDraft` (Bot API 9.5)
+
+### Dependencies to add
+
+```json
+{
+  "grammy": "^1.x",        // Bot API — TypeScript, tree-shakeable
+  "telegram": "^2.x"       // GramJS — MTProto client for group creation
+}
+```
+
+### IPC handlers to add in `src/main/ipc/index.ts`
+
+```ts
+'telegram:register-agent'   // Phase 0 alternative: register one bot
+'telegram:create-channel'   // Create group + invite all bots
+'telegram:start-bridge'     // Start grammY listeners for a team
+'telegram:stop-bridge'      // Stop listeners (team teardown)
+```
+
+---
+
+## Phase 3 — UI Integration
+
+**Goal**: Operators can set up and monitor Telegram from the Coordina UI.
+
+### New UI component: `TelegramCard`
+
+Added to the team detail panel, visible after a team is successfully deployed.
+
+**States:**
+1. **Not configured** — "Connect Telegram" button → triggers `telegram:create-channel` IPC
+2. **Configuring** — spinner with step labels (creating group, inviting bots)
+3. **Connected** — channel link, list of agent bot usernames, "Open in Telegram" button
+4. **Bridge running** — green indicator, message count, last activity timestamp
+
+**Location**: `src/renderer/src/components/TelegramCard.tsx`
+
+---
+
+## Phase 4 — Message Bridge (Bidirectional)
+
+**Goal**: Full two-way communication between humans in Telegram and agents in K8s.
+
+### Human → Agent flow
+
+1. Human sends a message in the team Telegram group
+2. grammY listener on the agent bot receives the message (Privacy Mode must be OFF or bot is admin)
+3. `bridge.ts` determines which agent should respond (lead agent by default, or via `@mention`)
+4. Message forwarded to agent's WebSocket gateway using existing proxy infrastructure
+5. Agent processes and returns response tokens
+
+### Agent → Human flow
+
+1. Agent emits an activity event (task complete, status update, error) via OpenClaw
+2. `bridge.ts` intercepts the event
+3. Agent's bot calls `sendMessageDraft` to stream the response into the group
+4. Final message replaces the draft (fully rendered in Telegram)
+
+### Thread-per-agent (optional enhancement)
+
+Use forum topics (supergroup with `is_forum: true`) to give each agent their own thread. This avoids a cluttered single-thread channel when multiple agents are active simultaneously.
+
+- `createForumTopic(chat_id, name: agentName, icon_color)` — one topic per agent
+- All agent responses go into their own named thread
+- Human replies go to the correct thread → auto-routes to that agent
+
+---
+
+## Key Files Summary
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Add telegram fields to `AgentSpec` and `TeamSpec` |
+| `src/main/ipc/index.ts` | Add 4 telegram IPC handlers |
+| `src/main/github/spec.ts` | Include `telegramUsername` in IDENTITY.md |
+| `src/main/integrations/telegram/register.ts` | New — bot registration via MTProto |
+| `src/main/integrations/telegram/channel.ts` | New — group creation and bot invitation |
+| `src/main/integrations/telegram/bridge.ts` | New — grammY listeners + WS routing |
+| `src/renderer/src/components/TelegramCard.tsx` | New — Telegram UI card |
+| `scripts/telegram/bootstrap.ts` | New — one-time operator setup script |
+
+---
+
+## Constraints & Decisions
+
+| Constraint | Decision |
+|---|---|
+| Max 20 bots per group | Coordina teams are typically 4–8 agents — well within limit |
+| Bots cannot read each other's messages | All inter-agent comms stay on OpenClaw WS layer |
+| Bots cannot self-join groups | One-time MTProto operator script handles invitations |
+| Bot tokens are sensitive | Stored in GCP Secret Manager, never in spec JSON committed to git |
+| Streaming 15% Stars commission | Irrelevant — internal team channels don't use Star payments |
+
+---
+
+## Verification Checklist
+
+- [ ] `@BotFather` bot created for one agent; bot appears in Telegram search
+- [ ] MTProto bootstrap script creates group and all agent bots appear as members
+- [ ] Privacy Mode confirmed OFF for each bot (or bot is group admin)
+- [ ] Human message in group → routed to agent gateway → response appears in Telegram
+- [ ] `sendMessageDraft` streams response token-by-token
+- [ ] Team spec JSON updated with `telegramChannelId` and per-agent `telegramUserId`
+- [ ] Coordina UI shows `TelegramCard` with channel link after deploy


### PR DESCRIPTION
# Telegram Integration for Coordina Agent Teams

Research into how each agent can have its own Telegram Bot identity and coordinate through a shared group channel.

## Changes
- **tg-research.md**: API reference, per-agent bot identity system, critical constraints (bots cannot read each other's messages)
- **tg-plan.md**: 4-phase implementation roadmap (bootstrap, spec, worker, UI, bridge)

## Key Findings
- Bot API 9.5 (March 1, 2026) enables streaming responses via `sendMessageDraft`
- Each agent registers via @BotFather → unique bot with ID, username, token
- Max 20 bots per Telegram group (sufficient for typical 4–8 agent teams)
- **Hard constraint**: Bots cannot receive messages from other bots in groups—Telegram serves as human-visible interface only; inter-agent comms stay on OpenClaw WebSocket layer

## Next Steps
Implement phases 0–4 in tg-plan.md: bootstrap (operator setup), spec extensions, bot registration worker, UI card, message bridge.