### PR TITLE
feat: add peer gateway discovery to agent openclaw.json

### DIFF
--- a/src/main/github/spec.test.ts
+++ b/src/main/github/spec.test.ts
@@ -61,6 +61,23 @@ describe('generateSkillsMd', () => {
   })
 })
 
+describe('generateOpenClawJson peers', () => {
+  it('serializes peers into openclaw.json when provided', () => {
+    const config: import('./spec').OpenClawConfig = {
+      agents: { defaults: { model: { primary: 'anthropic/claude-sonnet-4-6' } } },
+      models: { providers: { anthropic: {} } },
+      peers: {
+        beta: { url: 'http://agent-beta.my-team.svc.cluster.local:18789', token: 'tok-beta' },
+        gamma: { url: 'http://agent-gamma.my-team.svc.cluster.local:18789', token: 'tok-gamma' },
+      },
+    }
+    const parsed = JSON.parse(generateOpenClawJson(config))
+    expect(parsed.peers.beta.url).toBe('http://agent-beta.my-team.svc.cluster.local:18789')
+    expect(parsed.peers.beta.token).toBe('tok-beta')
+    expect(parsed.peers.gamma.url).toBe('http://agent-gamma.my-team.svc.cluster.local:18789')
+  })
+})
+
 describe('generateAgentsMd', () => {
   it('marks lead agent', () => {
     const md = generateAgentsMd([

--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -18,6 +18,7 @@ export interface OpenClawConfig {
   agents: { defaults: { model: { primary: string; fallbacks?: string[] } } }
   models: { providers: { [provider: string]: { apiKey?: string; baseUrl?: string; api?: string } } }
   gateway?: { auth?: { token?: string } }
+  peers?: { [slug: string]: { url: string; token: string } }
 }
 
 export function generateIdentityMd(agent: AgentIdentity): string {

--- a/src/main/specs/gke.test.ts
+++ b/src/main/specs/gke.test.ts
@@ -1,0 +1,78 @@
+// GKE deriver tests verifying peer gateway injection into agent openclaw.json
+// FEATURE: GKE derivation layer with K8s Secrets for API key security
+import { describe, it, expect, vi } from 'vitest'
+import yaml from 'js-yaml'
+import gkeDeriver from './gke'
+import type { TeamSpec, ProviderRecord } from '../../shared/types'
+
+vi.mock('../store/teams', () => ({ saveTeam: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('../providers/base', () => ({
+  getProvider: vi.fn().mockReturnValue({
+    toOpenClawJson: vi.fn().mockReturnValue({
+      agents: { defaults: { model: { primary: 'anthropic/claude-sonnet-4-6' } } },
+      models: { providers: { anthropic: {} } },
+    }),
+    toEnvVars: vi.fn().mockReturnValue({ ANTHROPIC_API_KEY: 'sk-test' }),
+  }),
+}))
+
+const teamSpec: TeamSpec = {
+  slug: 'my-team',
+  name: 'My Team',
+  domain: 'example.com',
+  tokenSeed: 'fixed-seed-for-testing-1234567890abcdef',
+  agents: [
+    { slug: 'alpha', name: 'Alpha', role: 'Lead', skills: [], soul: 'Alpha soul', providerSlug: 'anthropic', isLead: true },
+    { slug: 'beta', name: 'Beta', role: 'Engineer', skills: [], soul: 'Beta soul', providerSlug: 'anthropic', isLead: false },
+    { slug: 'gamma', name: 'Gamma', role: 'Designer', skills: [], soul: 'Gamma soul', providerSlug: 'anthropic', isLead: false },
+  ],
+}
+
+const providers = new Map<string, ProviderRecord & { apiKey?: string }>([
+  ['anthropic', { slug: 'anthropic', type: 'anthropic', name: 'Anthropic', model: 'claude-sonnet-4-6', apiKey: 'sk-test' }],
+])
+
+const envConfig = { projectId: 'my-project', clusterZone: 'us-central1-a' }
+
+function getOpenClawConfig(files: { path: string; content: string }[], agentSlug: string) {
+  const file = files.find(f => f.path === `agents/${agentSlug}/configmap.yaml`)!
+  const configmap = yaml.load(file.content) as { data: Record<string, string> }
+  return JSON.parse(configmap.data['openclaw.json'])
+}
+
+describe('gkeDeriver peer injection', () => {
+  it('includes all teammates as peers in each agent openclaw.json', async () => {
+    const files = await gkeDeriver.derive(teamSpec, providers, envConfig)
+    const alphaConfig = getOpenClawConfig(files, 'alpha')
+
+    expect(alphaConfig.peers).toBeDefined()
+    expect(alphaConfig.peers.beta).toBeDefined()
+    expect(alphaConfig.peers.gamma).toBeDefined()
+  })
+
+  it('excludes the agent itself from its own peers', async () => {
+    const files = await gkeDeriver.derive(teamSpec, providers, envConfig)
+    const alphaConfig = getOpenClawConfig(files, 'alpha')
+    const betaConfig = getOpenClawConfig(files, 'beta')
+
+    expect(alphaConfig.peers.alpha).toBeUndefined()
+    expect(betaConfig.peers.beta).toBeUndefined()
+  })
+
+  it('uses http:// URLs for peer gateways', async () => {
+    const files = await gkeDeriver.derive(teamSpec, providers, envConfig)
+    const alphaConfig = getOpenClawConfig(files, 'alpha')
+
+    expect(alphaConfig.peers.beta.url).toBe('http://agent-beta.my-team.svc.cluster.local:18789')
+    expect(alphaConfig.peers.gamma.url).toBe('http://agent-gamma.my-team.svc.cluster.local:18789')
+  })
+
+  it('includes auth token for each peer', async () => {
+    const files = await gkeDeriver.derive(teamSpec, providers, envConfig)
+    const alphaConfig = getOpenClawConfig(files, 'alpha')
+
+    expect(typeof alphaConfig.peers.beta.token).toBe('string')
+    expect(alphaConfig.peers.beta.token.length).toBeGreaterThan(0)
+    expect(alphaConfig.peers.beta.token).not.toBe(alphaConfig.peers.gamma.token)
+  })
+})

--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -103,7 +103,13 @@ const gkeDeriver: DeploymentSpecDeriver = {
         : {}
 
       const agentToken = deriveAgentToken(seed, agent.slug)
-      const openclawConfigWithGateway = { ...openclawConfig, gateway: { auth: { token: agentToken } } }
+      const agentPeers = peers
+        .filter(p => p.slug !== agent.slug)
+        .reduce<Record<string, { url: string; token: string }>>((acc, p) => {
+          acc[p.slug] = { url: `http://agent-${p.slug}.${namespace}.svc.cluster.local:18789`, token: p.token }
+          return acc
+        }, {})
+      const openclawConfigWithGateway = { ...openclawConfig, gateway: { auth: { token: agentToken } }, peers: agentPeers }
       const credentialSecretName = `${spec.slug}-${agent.slug}-credentials`
       files.push({ path: `agents/${agent.slug}/pv.yaml`, content: generateAgentPv({ teamSlug: spec.slug, agentSlug: agent.slug, projectId, zone: diskZone ?? clusterZone, storageGi: agent.storageGi }) })
       files.push({ path: `agents/${agent.slug}/pvc.yaml`, content: generateAgentPvc({ teamSlug: spec.slug, agentSlug: agent.slug, namespace, storageGi: agent.storageGi }) })


### PR DESCRIPTION
## Summary

Enable all agents on a team to discover and connect to each other's gateways for peer-to-peer communication. Each agent's `openclaw.json` now includes a `peers` section with HTTP gateway URLs and deterministic auth tokens for all teammates (excluding self).

## Changes

- Add `peers` field to `OpenClawConfig` interface in spec.ts
- Generate filtered peer list for each agent in GKE deriver (all teammates except self)
- Use `http://` URLs pointing to K8s service DNS for peer HTTP API calls
- Derive peer tokens from existing `tokenSeed` using deterministic HMAC-SHA256
- Add comprehensive test coverage verifying peer injection, filtering, and token uniqueness

## How It Works

Agents no longer need to parse `TEAM.md` for gateway discovery. OpenClaw's runtime can natively read the structured `peers` configuration and establish P2P connections within the same cluster via K8s service DNS.

## Testing

All new tests pass. Existing failures are pre-existing and unrelated to these changes.