### PR TITLE
Configure OpenClaw Telegram mention patterns

### DIFF
--- a/src/main/specs/gke.test.ts
+++ b/src/main/specs/gke.test.ts
@@ -155,6 +155,7 @@ describe('gkeDeriver telegram config', () => {
     expect(alphaConfig.channels.telegram.groupPolicy).toBe('allowlist')
     expect(alphaConfig.channels.telegram.groupAllowFrom).toEqual(['222222222'])
     expect(alphaConfig.channels.telegram.groups['-1001234567890']).toEqual({ requireMention: true })
+    expect(alphaConfig.messages.groupChat.mentionPatterns).toEqual(['@all', '@agents', '@team', '@111111111'])
     expect(alphaConfig.channels.telegram.enabled).toBe(true)
   })
 })

--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -146,6 +146,9 @@ const gkeDeriver: DeploymentSpecDeriver = {
             },
           }
         : undefined
+      const telegramMessagesConfig = hasTelegramRouting
+        ? { groupChat: { mentionPatterns: ['@all', '@agents', '@team', `@${telegramBotId}`] } }
+        : undefined
       const baseGateway = (openclawConfig as { gateway?: Record<string, unknown> }).gateway ?? {}
       const baseHttp = (baseGateway.http as { endpoints?: Record<string, unknown> } | undefined) ?? {}
       const baseEndpoints = baseHttp.endpoints ?? {}
@@ -167,6 +170,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
         ...((baseChannels || telegramChannelsConfig)
           ? { channels: { ...(baseChannels ?? {}), ...(telegramChannelsConfig ?? {}) } }
           : {}),
+        ...(telegramMessagesConfig ? { messages: telegramMessagesConfig } : {}),
         tools: {
           ...baseTools,
           profile: (baseTools.profile as string | undefined) ?? 'full',


### PR DESCRIPTION
Set requireMention: true in telegram.groups config and define mentionPatterns at messages.groupChat level to enable bots to respond when mentioned with @all, @agents, @team, or their own bot ID. Tests updated to verify the correct OpenClaw config structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)