### PR TITLE
refactor: remove emoji field from AgentSpec

### DIFF
--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -209,7 +209,6 @@ const gkeDeriver: DeploymentSpecDeriver = {
         name: agent.name,
         role: agent.role,
         persona: agent.persona,
-        emoji: agent.emoji,
         avatar: agent.avatar,
         teamName: spec.name,
         teamSlug: spec.slug,

--- a/src/main/store/teams.ts
+++ b/src/main/store/teams.ts
@@ -19,6 +19,7 @@ function migrateAgent(a: Record<string, unknown>): Record<string, unknown> {
   if ('githubId' in out && !('githubUsername' in out)) { out.githubUsername = out.githubId; delete out.githubId }
   if ('slackHandle' in out && !('slack' in out)) { out.slack = out.slackHandle; delete out.slackHandle }
   if ('storageGi' in out && !('diskGi' in out)) { out.diskGi = out.storageGi; delete out.storageGi }
+  delete out.emoji
   delete out.isLead
   return out
 }

--- a/src/main/validation/teamSpecNormalize.ts
+++ b/src/main/validation/teamSpecNormalize.ts
@@ -18,7 +18,6 @@ function normalizeAgent(agent: AgentSpec): AgentSpec {
     slug: normalizeOptional(agent.slug) ?? '',
     name: normalizeOptional(agent.name) ?? '',
     role: normalizeOptional(agent.role) ?? '',
-    emoji: normalizeOptional(agent.emoji),
     avatar: normalizeOptional(agent.avatar),
     telegramBot: normalizeOptional(agent.telegramBot),
     email: normalizeOptional(agent.email),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -18,7 +18,6 @@ export interface AgentSpec {
   slug: string
   name: string
   role: string
-  emoji?: string
   avatar?: string
   telegramBot?: string
   email?: string


### PR DESCRIPTION
Remove the emoji field from AgentSpec type and all references, as it was already absent from the UI but persisted in JSON files. Adds a migration function to strip emoji from existing agent records when loaded. This cleans up the team spec data model and ensures consistency between code and persisted state.