### PR TITLE
fix: make UI text selectable and copyable

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -15,6 +15,10 @@ body {
   font-size: 14px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   -webkit-font-smoothing: antialiased;
+  user-select: text;
+}
+
+button, [role="button"], [role="tab"], [role="menuitem"] {
   user-select: none;
 }
 


### PR DESCRIPTION
Enable text selection throughout the UI by changing user-select from none to text on the body element, while preserving non-selectable behavior for interactive elements like buttons, tabs, and menu items.