### PR TITLE
UI consistency: swap crown/status indicators and align font sizes

### DIFF
--- a/src/renderer/src/components/TeamContent.tsx
+++ b/src/renderer/src/components/TeamContent.tsx
@@ -277,13 +277,13 @@ export function TeamContent({ slug }: { slug: string }) {
                     </span>
                     <span className="truncate">{agent.name}</span>
                     <span className="ml-auto flex items-center gap-1 shrink-0">
-                      {isDeployed && (
-                        <span className={`w-1.5 h-1.5 rounded-full ${statusDotClass(agentStatuses.get(agent.slug))}`} />
-                      )}
                       {i === 0 && (
                         <span className="text-gray-400">
                           <Crown className="w-3 h-3" />
                         </span>
+                      )}
+                      {isDeployed && (
+                        <span className={`w-1.5 h-1.5 rounded-full ${statusDotClass(agentStatuses.get(agent.slug))}`} />
                       )}
                     </span>
                   </button>

--- a/src/renderer/src/components/files/MarkdownViewer.tsx
+++ b/src/renderer/src/components/files/MarkdownViewer.tsx
@@ -49,7 +49,7 @@ export function MarkdownViewer({ content, filePath }: Props) {
 
       <div className="flex-1 overflow-auto p-4">
         {viewSource || !isMarkdown ? (
-          <pre className="text-sm font-mono text-gray-700 whitespace-pre-wrap leading-relaxed">
+          <pre className="text-xs font-mono text-gray-700 whitespace-pre-wrap leading-relaxed">
             {isHighlightable(filePath) ? highlightContent(content, filePath) : content}
           </pre>
         ) : (


### PR DESCRIPTION
Reorder lead agent indicators so crown icon appears before deployment status dot. Align Files source view font size (text-xs) to match Deployment file view for visual consistency across the app.