### PR TITLE
fix: preserve role selection when editing agent specs

### DIFF
--- a/src/renderer/src/components/team/AgentCard.tsx
+++ b/src/renderer/src/components/team/AgentCard.tsx
@@ -44,7 +44,15 @@ export function AgentCard({
     onChange({ ...agent, [key]: value })
 
   const personasByDivision = useMemo(() => getPersonasByDivision(), [])
-  const [selectedTemplate, setSelectedTemplate] = useState<string>('')
+  const [selectedTemplate, setSelectedTemplate] = useState<string>(() => {
+    if (agent.role || agent.persona || agent.skills.length > 0) {
+      const match = PERSONA_CATALOG.find(
+        (p) => p.role === agent.role && p.persona === agent.persona,
+      )
+      return match?.id ?? 'custom'
+    }
+    return ''
+  })
 
   const applyTemplate = (templateId: string) => {
     setSelectedTemplate(templateId)


### PR DESCRIPTION
## Summary
- Initialize selectedTemplate state from existing agent data (role/persona/skills)
- Matches agent to catalog template if found, otherwise sets 'custom' 
- Fixes issue where Role/Persona/Skills fields were hidden when editing existing agents

## Test Plan
- [ ] Edit an agent with existing role/persona data
- [ ] Verify Role/Persona/Skills fields are now visible
- [ ] Verify template matches if exact match exists in catalog
- [ ] Verify 'custom' is selected if no exact match but agent has role data