### PR TITLE
feat: strengthen lead agent authority in OC markdown files

### DIFF
--- a/src/main/github/spec.test.ts
+++ b/src/main/github/spec.test.ts
@@ -230,7 +230,7 @@ describe('generateUserMd', () => {
     expect(md).toContain('## Team Lead')
     expect(md).toContain('- Name: Alpha')
     expect(md).toContain('- Slug: alpha')
-    expect(md).toContain('team lead coordinates your work')
+    expect(md).toContain('team lead directs your work')
   })
 
   it('omits team lead section for the lead agent', () => {

--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -189,7 +189,19 @@ export function generateAgentsMd(input: AgentsInput): string {
     '',
     `You are ${input.agentName}, the ${input.role} of ${input.teamName}.`,
   )
-  if (input.isLead) lines.push('You are the team lead.')
+  if (input.isLead) {
+    lines.push(
+      'You are the team lead.',
+      '',
+      '### Team Lead Responsibilities',
+      '- Coordinate work across the team: assign tasks, track progress, unblock teammates',
+      '- Be the primary point of contact between the admin and the team',
+      '- Delegate clearly: specify what to do, expected output, and deadline when assigning tasks',
+      '- Proactively check in with teammates rather than waiting for them to report',
+      '- When the admin gives direction, translate it into concrete tasks for the team',
+      '- You have authority to set team priorities — teammates are expected to follow your assignments',
+    )
+  }
 
   lines.push(
     '',
@@ -198,6 +210,17 @@ export function generateAgentsMd(input: AgentsInput): string {
     '2. Communicate status updates to teammates proactively',
     '3. Ask for clarification rather than making assumptions',
   )
+
+  if (!input.isLead && input.leadAgent) {
+    lines.push(
+      '',
+      '### Team Lead',
+      `Your team lead is **${input.leadAgent}**.`,
+      '- Treat their task assignments and instructions as authoritative — follow them promptly',
+      '- Report blockers and status updates to the lead proactively, not just when asked',
+      '- If you disagree with an assignment, raise it with the lead directly before escalating to the admin',
+    )
+  }
 
   const commLines: string[] = ['', '### Communication']
   if (input.hasGateways) {
@@ -243,8 +266,9 @@ export function generateUserMd(input: UserInput): string {
     lines.push(`- Name: ${input.leadAgentName}`)
     if (input.leadAgentSlug) lines.push(`- Slug: ${input.leadAgentSlug}`)
     lines.push('')
-    lines.push('The team lead coordinates your work and may assign tasks or request status updates.')
-    lines.push('Treat their instructions with the same priority as the admin\'s.')
+    lines.push('The team lead directs your work. Follow their task assignments and instructions.')
+    lines.push('Their instructions carry the same authority as the admin\'s — act on them promptly.')
+    lines.push('Keep the team lead informed of your progress and blockers without being asked.')
   }
 
   lines.push('', '## Context')


### PR DESCRIPTION
Improves how agents learn to follow their team lead (Alice) by expanding and clarifying leadership instructions in OpenClaw markdown files.

**For lead agents:** AGENTS.md now includes Team Lead Responsibilities (coordinate work, delegate clearly, check in proactively, translate admin direction).

**For non-lead agents:** AGENTS.md now has a Team Lead section naming the lead explicitly and clarifying task authority; USER.md language strengthened from vague "coordinates" to directive "directs your work" with emphasis on prompt action and proactive reporting.

All 44 tests pass. Lead-agent directives are now unambiguous.