### PR TITLE
feat: non-blocking P2P communication and multi-project support

### DIFF
--- a/src/main/environments/gke/manifests.ts
+++ b/src/main/environments/gke/manifests.ts
@@ -37,13 +37,16 @@ export function generateTeamConfigMap(input: {
   namespace: string
   teamMd: string
   bootstrapMd: string
+  projectsMd?: string
 }): string {
-  const { teamSlug, namespace, teamMd, bootstrapMd } = input
+  const { teamSlug, namespace, teamMd, bootstrapMd, projectsMd } = input
+  const data: Record<string, string> = { 'TEAM.md': teamMd, 'BOOTSTRAP.md': bootstrapMd }
+  if (projectsMd) data['PROJECTS.md'] = projectsMd
   return generateConfigMap({
     name: `${teamSlug}-shared-config`,
     namespace,
     labels: { 'coordina.team': teamSlug },
-    data: { 'TEAM.md': teamMd, 'BOOTSTRAP.md': bootstrapMd },
+    data,
   })
 }
 
@@ -143,6 +146,7 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
     `mkdir -p ${stateDir} ${workspaceDir}`,
     `test -f ${workspaceDir}/BOOTSTRAP.md || cp /config/shared/BOOTSTRAP.md ${workspaceDir}/BOOTSTRAP.md`,
     `cp /config/shared/TEAM.md ${workspaceDir}/TEAM.md`,
+    `test -f /config/shared/PROJECTS.md && cp /config/shared/PROJECTS.md ${workspaceDir}/PROJECTS.md || true`,
     `cp /config/agent/IDENTITY.md ${workspaceDir}/IDENTITY.md`,
     `test -f ${workspaceDir}/MEMORY.md || cp /config/agent/MEMORY.md ${workspaceDir}/MEMORY.md`,
     `test -f ${workspaceDir}/SOUL.md || cp /config/agent/SOUL.md ${workspaceDir}/SOUL.md`,
@@ -195,6 +199,7 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
             env: [
               { name: 'OPENCLAW_WORKSPACE_DIR', value: workspaceDir },
               { name: 'OPENCLAW_STATE_DIR', value: stateDir },
+              { name: 'OPENCLAW_HOST', value: '0.0.0.0' },
             ],
             ...(credentialSecretName ? { envFrom: [{ secretRef: { name: credentialSecretName } }] } : {}),
             volumeMounts: containerVolumeMounts,

--- a/src/main/github/spec.test.ts
+++ b/src/main/github/spec.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateIdentityMd, generateMemoryMd, generateSoulMd, generateOpenClawJson, generateSkillsMd, generateAgentsMd, generateTeamMd, generateUserMd, generateToolsMd } from './spec'
+import { generateIdentityMd, generateMemoryMd, generateSoulMd, generateOpenClawJson, generateSkillsMd, generateAgentsMd, generateTeamMd, generateUserMd, generateToolsMd, generateProjectsMd } from './spec'
 
 describe('generateIdentityMd', () => {
   it('outputs key-value format with Name and Creature', () => {
@@ -147,7 +147,7 @@ describe('generateOpenClawJson gateway', () => {
 })
 
 describe('generateAgentsMd', () => {
-  const base = { agentName: 'Alpha', role: 'Lead', teamName: 'Team Phoenix', isLead: true, hasTelegram: false, hasGateways: false }
+  const base = { agentName: 'Alpha', agentSlug: 'alpha', role: 'Lead', teamName: 'Team Phoenix', isLead: true, hasTelegram: false, hasGateways: false, hasProjects: false }
 
   it('includes OpenClaw defaults and team operating instructions', () => {
     const md = generateAgentsMd(base)
@@ -195,6 +195,46 @@ describe('generateAgentsMd', () => {
     const md = generateAgentsMd(base)
     expect(md).toContain('### Priorities')
     expect(md).toContain('TEAM.md')
+  })
+
+  it('includes multi-project protocol when hasProjects', () => {
+    const md = generateAgentsMd({ ...base, hasProjects: true })
+    expect(md).toContain('### Multi-Project Protocol')
+    expect(md).toContain('PROJECTS.md')
+    expect(md).toContain('[project-slug]')
+  })
+
+  it('omits multi-project protocol when no projects', () => {
+    const md = generateAgentsMd(base)
+    expect(md).not.toContain('### Multi-Project Protocol')
+  })
+
+  it('includes async communication guidance when hasGateways', () => {
+    const md = generateAgentsMd({ ...base, hasGateways: true })
+    expect(md).toContain('[ASYNC]')
+    expect(md).toContain('blocking curl')
+  })
+})
+
+describe('generateProjectsMd', () => {
+  it('generates project listing with members and status', () => {
+    const md = generateProjectsMd([
+      { slug: 'alpha', name: 'Project Alpha', description: 'Frontend redesign', members: ['alice', 'bob'], status: 'active' },
+      { slug: 'beta', name: 'Project Beta', description: 'API migration', members: ['alice', 'charlie'], status: 'paused' },
+    ])
+    expect(md).toContain('# Projects')
+    expect(md).toContain('## Project Alpha')
+    expect(md).toContain('- slug: alpha')
+    expect(md).toContain('- status: active')
+    expect(md).toContain('- members: alice, bob')
+    expect(md).toContain('- workspace: projects/alpha/')
+    expect(md).toContain('## Project Beta')
+    expect(md).toContain('- status: paused')
+  })
+
+  it('shows placeholder for empty projects', () => {
+    const md = generateProjectsMd([])
+    expect(md).toContain('No projects defined')
   })
 })
 
@@ -246,31 +286,48 @@ describe('generateUserMd', () => {
 
 describe('generateToolsMd', () => {
   it('includes inter-agent communication when hasGateways', () => {
-    const md = generateToolsMd({ hasGateways: true })
+    const md = generateToolsMd({ hasGateways: true, hasProjects: false })
     expect(md).toContain('# Tools')
     expect(md).toContain('## Inter-Agent Communication')
-    expect(md).toContain('curl -s -m 300')
-    expect(md).toContain('POST <gateway>/v1/responses')
+    expect(md).toContain('### Quick Request')
+    expect(md).toContain('### Task Delegation')
+    expect(md).toContain('### Responding to Async Requests')
     expect(md).toContain('Authorization: Bearer <gateway_token>')
     expect(md).toContain('Do NOT use OpenClaw node/tailnet commands')
   })
 
+  it('includes agent gateway URL in async delegation example', () => {
+    const md = generateToolsMd({ hasGateways: true, hasProjects: false, agentGatewayUrl: 'http://agent-alice.team.svc.cluster.local:18789' })
+    expect(md).toContain('http://agent-alice.team.svc.cluster.local:18789')
+  })
+
   it('omits inter-agent section when no gateways', () => {
-    const md = generateToolsMd({ hasGateways: false })
+    const md = generateToolsMd({ hasGateways: false, hasProjects: false })
     expect(md).toContain('# Tools')
     expect(md).toContain('## Workspace')
     expect(md).not.toContain('## Inter-Agent Communication')
   })
 
+  it('includes project-scoped messages when hasProjects', () => {
+    const md = generateToolsMd({ hasGateways: true, hasProjects: true })
+    expect(md).toContain('## Project-Scoped Messages')
+    expect(md).toContain('[project-alpha]')
+  })
+
+  it('omits project-scoped messages when no projects', () => {
+    const md = generateToolsMd({ hasGateways: true, hasProjects: false })
+    expect(md).not.toContain('## Project-Scoped Messages')
+  })
+
   it('includes custom tool guidance', () => {
-    const md = generateToolsMd({ hasGateways: false, toolGuidance: ['Use exec for shell commands', 'Prefer jq for JSON'] })
+    const md = generateToolsMd({ hasGateways: false, hasProjects: false, toolGuidance: ['Use exec for shell commands', 'Prefer jq for JSON'] })
     expect(md).toContain('## Custom Guidance')
     expect(md).toContain('- Use exec for shell commands')
     expect(md).toContain('- Prefer jq for JSON')
   })
 
   it('always includes workspace section', () => {
-    const md = generateToolsMd({ hasGateways: true })
+    const md = generateToolsMd({ hasGateways: true, hasProjects: false })
     expect(md).toContain('## Workspace')
   })
 })

--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -22,7 +22,6 @@ export interface OpenClawConfig {
   agents: { defaults: { model: { primary: string; fallbacks?: string[] } } }
   models: { providers: { [provider: string]: { apiKey?: string; baseUrl?: string; api?: string } } }
   gateway?: {
-    host?: string
     auth?: { token?: string }
     http?: {
       endpoints?: {
@@ -41,12 +40,14 @@ export interface OpenClawConfig {
 
 export interface AgentsInput {
   agentName: string
+  agentSlug: string
   role: string
   teamName: string
   leadAgent?: string
   isLead: boolean
   hasTelegram: boolean
   hasGateways: boolean
+  hasProjects: boolean
   operatingRules?: string[]
 }
 
@@ -62,6 +63,8 @@ export interface UserInput {
 
 export interface ToolsInput {
   hasGateways: boolean
+  hasProjects: boolean
+  agentGatewayUrl?: string
   toolGuidance?: string[]
 }
 
@@ -225,12 +228,28 @@ export function generateAgentsMd(input: AgentsInput): string {
 
   const commLines: string[] = ['', '### Communication']
   if (input.hasGateways) {
-    commLines.push('- To reach a teammate, read TEAM.md for their gateway URL and use the exec tool with curl (see TOOLS.md)')
+    commLines.push(
+      '- To reach a teammate, read TEAM.md for their gateway URL and use the exec tool with curl (see TOOLS.md)',
+      '- For quick questions (< 1 min expected response), use a blocking curl call',
+      '- For longer tasks, use the async pattern: send with `[ASYNC]` prefix so the recipient sends results back to your gateway when done',
+    )
   }
   if (input.hasTelegram) {
     commLines.push('- When `@all` is used in Telegram, you MUST respond')
   }
   if (commLines.length > 2) lines.push(...commLines)
+
+  if (input.hasProjects) {
+    lines.push(
+      '',
+      '### Multi-Project Protocol',
+      '- Read `PROJECTS.md` at session start to see active projects and your assignments',
+      '- Tag all inter-agent messages with `[project-slug]` prefix so teammates know the context',
+      '- Keep project files in `workspace/projects/<slug>/` to separate work streams',
+      '- When delegating, always specify which project the task belongs to',
+      '- You can context-switch between projects — use project directories to maintain separate state',
+    )
+  }
 
   const ruleLines: string[] = [
     '',
@@ -288,16 +307,44 @@ export function generateToolsMd(input: ToolsInput): string {
       'To message a teammate, use the `exec` tool to call their gateway HTTP API.',
       'Read TEAM.md for gateway URLs and tokens.',
       '',
-      'Example:',
+      '### Quick Request (blocking — use for short questions)',
       '```',
-      'curl -s -m 300 -X POST <gateway>/v1/responses \\',
+      'curl -s -m 60 -X POST <gateway>/v1/responses \\',
       '  -H "Authorization: Bearer <gateway_token>" \\',
       '  -H "Content-Type: application/json" \\',
-      '  -d \'{"model": "anthropic/claude-sonnet-4-6", "input": "Your message here"}\'',
+      '  -d \'{"model": "anthropic/claude-sonnet-4-6", "input": "Your question here"}\'',
       '```',
       '',
-      'The `-m 300` flag sets a 5-minute timeout. Replace `<gateway>` and `<gateway_token>` with values from TEAM.md.',
+      '### Task Delegation (non-blocking — use for tasks that take > 1 minute)',
+      'Send the task with an `[ASYNC]` prefix. The recipient will send results back to your gateway when done.',
+      '```',
+      'curl -s -m 30 -X POST <teammate-gateway>/v1/responses \\',
+      '  -H "Authorization: Bearer <gateway_token>" \\',
+      '  -H "Content-Type: application/json" \\',
+      `  -d '{"model": "anthropic/claude-sonnet-4-6", "input": "[ASYNC] <task description>. When done, send results to my gateway: ${input.agentGatewayUrl ?? '<my-gateway>'}"}' &`,
+      '```',
+      'The `&` at the end runs the curl in the background so you can continue working.',
+      '',
+      '### Responding to Async Requests',
+      'When you receive a message prefixed with `[ASYNC]`:',
+      '1. Complete the requested work',
+      '2. Send results back to the sender\'s gateway (URL will be in the message)',
+      '3. Use a blocking curl for the response since it should be a short status update',
+      '',
+      'Replace `<gateway>` and `<gateway_token>` with values from TEAM.md.',
       'Do NOT use OpenClaw node/tailnet commands.',
+    )
+  }
+
+  if (input.hasProjects) {
+    lines.push(
+      '',
+      '## Project-Scoped Messages',
+      'When messaging teammates about a specific project, prefix the message with the project slug:',
+      '```',
+      'curl ... -d \'{"input": "[project-alpha] Review the API schema changes"}\'',
+      '```',
+      'This helps teammates route context correctly when working on multiple projects.',
     )
   }
 
@@ -314,5 +361,28 @@ export function generateToolsMd(input: ToolsInput): string {
   }
 
   lines.push('')
+  return lines.join('\n')
+}
+
+export interface ProjectInput {
+  slug: string
+  name: string
+  description: string
+  members: string[]
+  status: 'active' | 'paused' | 'completed'
+}
+
+export function generateProjectsMd(projects: ProjectInput[]): string {
+  if (projects.length === 0) return '# Projects\n\n_No projects defined yet._\n'
+  const lines: string[] = ['# Projects', '']
+  for (const p of projects) {
+    lines.push(`## ${p.name}`)
+    lines.push(`- slug: ${p.slug}`)
+    lines.push(`- status: ${p.status}`)
+    lines.push(`- description: ${p.description}`)
+    lines.push(`- members: ${p.members.join(', ')}`)
+    lines.push(`- workspace: projects/${p.slug}/`)
+    lines.push('')
+  }
   return lines.join('\n')
 }

--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -22,6 +22,7 @@ import {
   generateUserMd,
   generateToolsMd,
   generateOpenClawJson,
+  generateProjectsMd,
 } from '../github/spec'
 
 import { DEFAULT_BOOTSTRAP_INSTRUCTIONS } from './bootstrap'
@@ -106,11 +107,14 @@ const gkeDeriver: DeploymentSpecDeriver = {
       })),
     })
     const bootstrapMd = spec.startupInstructions || DEFAULT_BOOTSTRAP_INSTRUCTIONS
-    const teamConfig = generateTeamConfigMap({ teamSlug: spec.slug, namespace, teamMd, bootstrapMd })
+    const hasProjects = Boolean(spec.projects && spec.projects.length > 0)
+    const projectsMd = hasProjects ? generateProjectsMd(spec.projects!) : undefined
+    const teamConfig = generateTeamConfigMap({ teamSlug: spec.slug, namespace, teamMd, bootstrapMd, projectsMd })
     const teamConfigHash = createHash('sha256').update(teamConfig).digest('hex')
 
     files.push({ path: 'TEAM.md', content: teamMd })
     files.push({ path: 'BOOTSTRAP.md', content: bootstrapMd })
+    if (projectsMd) files.push({ path: 'PROJECTS.md', content: projectsMd })
     files.push({ path: 'configmap-shared.yaml', content: teamConfig })
 
     for (const agent of spec.agents) {
@@ -179,7 +183,6 @@ const gkeDeriver: DeploymentSpecDeriver = {
         gateway: {
           ...baseGateway,
           mode: 'local',
-          host: '0.0.0.0',
           auth: {
             ...((baseGateway.auth as Record<string, unknown> | undefined) ?? {}),
             token: agentToken,
@@ -218,14 +221,17 @@ const gkeDeriver: DeploymentSpecDeriver = {
       const memoryMd = generateMemoryMd()
       const soulMd = generateSoulMd({ userInput: agent.persona, tone: agent.tone, boundaries: agent.boundaries, values: agent.values })
       const skillsMd = generateSkillsMd(agent.skills)
+      const agentGatewayUrl = `http://agent-${agent.slug}.${namespace}.svc.cluster.local:18789`
       const agentsMd = generateAgentsMd({
         agentName: agent.name,
+        agentSlug: agent.slug,
         role: agent.role,
         teamName: spec.name,
         leadAgent: spec.leadAgent,
         isLead: agent.slug === spec.leadAgent,
         hasTelegram: hasTelegramRouting,
         hasGateways,
+        hasProjects,
         operatingRules: agent.operatingRules,
       })
       const leadAgent = spec.agents.find(a => a.slug === spec.leadAgent)
@@ -240,6 +246,8 @@ const gkeDeriver: DeploymentSpecDeriver = {
       })
       const toolsMd = generateToolsMd({
         hasGateways,
+        hasProjects,
+        agentGatewayUrl,
         toolGuidance: agent.toolGuidance,
       })
       const openclawJson = generateOpenClawJson(openclawConfigWithGateway)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -45,6 +45,15 @@ export interface TeamSpec {
   adminName?: string
   adminEmail?: string
   teamDescription?: string
+  projects?: ProjectSpec[]
+}
+
+export interface ProjectSpec {
+  slug: string
+  name: string
+  description: string
+  members: string[]
+  status: 'active' | 'paused' | 'completed'
 }
 
 export interface PersonaTemplate {


### PR DESCRIPTION
## Summary

This PR enables two major OpenClaw collaboration capabilities and fixes a critical GKE deployment issue.

### Non-Blocking P2P Communication (Deliverable 1)

Agents can now delegate work asynchronously without blocking the sender:

- **Quick Request pattern** (blocking, <1 min): `curl -m 60 -X POST ...` for short questions
- **Task Delegation pattern** (non-blocking): `curl ... & ` with `[ASYNC]` prefix so sender continues working
- **Async Response protocol**: Recipient completes task and sends results back to sender's gateway

Updated guidance in TOOLS.md and AGENTS.md with code examples for both patterns.

### Multi-Project Support (Deliverable 2)

Teams can now work on multiple projects simultaneously with proper organization:

- **ProjectSpec interface**: Models project metadata (slug, name, description, members, status)
- **PROJECTS.md manifest**: Lists active projects, generated from team spec
- **Multi-Project Protocol in AGENTS.md**: Instructions to read PROJECTS.md, tag messages with `[project-slug]`, keep per-project workspace dirs
- **Project-scoped messaging**: Examples in TOOLS.md showing `[project-slug]` prefix pattern
- **Workspace organization**: Agents maintain separate state under `workspace/projects/<slug>/` per project

### GKE Pod Crash Fix

**Problem**: All agents deployed to GKE were in CrashLoopBackOff with error:
\`\`\`
Invalid config at openclaw.json: gateway: Unrecognized key: host
\`\`\`

**Root Cause**: Code was adding `host: '0.0.0.0'` to the gateway config object, but OpenClaw's strict config validator rejects unknown keys. OpenClaw uses the `OPENCLAW_HOST` environment variable to bind the gateway socket, not a config key.

**Solution**:
- Remove `gateway.host` from openclaw.json generation
- Add `OPENCLAW_HOST=0.0.0.0` to container environment variables
- Pods now start successfully and agents can communicate via gateway

## Changes

| File | Changes |
|------|---------|
| `src/shared/types.ts` | Add `ProjectSpec` interface, extend `TeamSpec` with `projects?` field |
| `src/main/github/spec.ts` | Add `generateProjectsMd()`, update `generateAgentsMd()` and `generateToolsMd()` with async/project patterns |
| `src/main/specs/gke.ts` | Wire projects generation, fix gateway config, update agent generators |
| `src/main/environments/gke/manifests.ts` | Update ConfigMap for PROJECTS.md, fix environment variables |
| `src/main/github/spec.test.ts` | Add tests for project functionality and async communication patterns |

## Verification

- ✅ TypeScript compiles cleanly
- ✅ All spec generator tests pass
- ✅ Generated YAML manifests are valid Kubernetes objects
- ✅ OpenClaw config validation passes

## Technical Details

The research revealed that true async P2P communication requires all agents on the same Gateway instance (using \`sessions_send\`). Since Coordina uses one Gateway per agent (separate StatefulSets), agents communicate via HTTP \`POST /v1/responses\`.

The async pattern solves this: sender fires off a request with \`[ASYNC]\` prefix and continues working, while the recipient sends results back asynchronously.

Agents can context-switch between projects while maintaining separate state under \`workspace/projects/<slug>/\` directories, enabling natural multi-project workflows without architectural changes.