### PR TITLE
fix: remove hardcoded model from tools.md curl example

### DIFF
--- a/src/main/github/spec.test.ts
+++ b/src/main/github/spec.test.ts
@@ -246,13 +246,19 @@ describe('generateUserMd', () => {
 
 describe('generateToolsMd', () => {
   it('includes inter-agent communication when hasGateways', () => {
-    const md = generateToolsMd({ hasGateways: true })
+    const md = generateToolsMd({ hasGateways: true, primaryModel: 'anthropic/claude-sonnet-4-6' })
     expect(md).toContain('# Tools')
     expect(md).toContain('## Inter-Agent Communication')
     expect(md).toContain('curl -s -m 300')
     expect(md).toContain('POST <gateway>/v1/responses')
     expect(md).toContain('Authorization: Bearer <gateway_token>')
     expect(md).toContain('Do NOT use OpenClaw node/tailnet commands')
+    expect(md).toContain('"model": "anthropic/claude-sonnet-4-6"')
+  })
+
+  it('uses placeholder model when primaryModel is not provided', () => {
+    const md = generateToolsMd({ hasGateways: true })
+    expect(md).toContain('"model": "<model>"')
   })
 
   it('omits inter-agent section when no gateways', () => {

--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -62,6 +62,7 @@ export interface UserInput {
 
 export interface ToolsInput {
   hasGateways: boolean
+  primaryModel?: string
   toolGuidance?: string[]
 }
 
@@ -293,7 +294,7 @@ export function generateToolsMd(input: ToolsInput): string {
       'curl -s -m 300 -X POST <gateway>/v1/responses \\',
       '  -H "Authorization: Bearer <gateway_token>" \\',
       '  -H "Content-Type: application/json" \\',
-      '  -d \'{"model": "anthropic/claude-sonnet-4-6", "input": "Your message here"}\'',
+      `  -d '{"model": "${input.primaryModel ?? '<model>'}", "input": "Your message here"}'`,
       '```',
       '',
       'The `-m 300` flag sets a 5-minute timeout. Replace `<gateway>` and `<gateway_token>` with values from TEAM.md.',

--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -141,7 +141,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
               groupPolicy: 'allowlist',
               groupAllowFrom: [telegramAdminId!],
               groups: {
-                [telegramGroupId!]: { requireMention: true },
+                [telegramGroupId!]: { requireMention: agent.slug !== spec.leadAgent },
               },
               streaming: 'partial',
             },
@@ -240,6 +240,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
       })
       const toolsMd = generateToolsMd({
         hasGateways,
+        primaryModel: openclawConfig.agents?.defaults?.model?.primary,
         toolGuidance: agent.toolGuidance,
       })
       const openclawJson = generateOpenClawJson(openclawConfigWithGateway)


### PR DESCRIPTION
Pass the agent's configured primaryModel to generateToolsMd instead of hardcoding anthropic/claude-sonnet-4-6. The curl example now includes the team's actual configured model or falls back to a <model> placeholder if not provided. Also fixes lead agent telegram mention requirement.