### PR TITLE
Fix GKE OpenClaw gateway bind

### DIFF
--- a/src/main/github/spec.test.ts
+++ b/src/main/github/spec.test.ts
@@ -131,9 +131,11 @@ describe('generateOpenClawJson gateway', () => {
     const config: import('./spec').OpenClawConfig = {
       agents: { defaults: { model: { primary: 'anthropic/claude-sonnet-4-6' } } },
       models: { providers: { anthropic: {} } },
-      gateway: { auth: { token: 'tok-gateway' } },
+      gateway: { bind: 'lan', auth: { mode: 'token', token: 'tok-gateway' } },
     }
     const parsed = JSON.parse(generateOpenClawJson(config))
+    expect(parsed.gateway.bind).toBe('lan')
+    expect(parsed.gateway.auth.mode).toBe('token')
     expect(parsed.gateway.auth.token).toBe('tok-gateway')
   })
 })

--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -23,8 +23,12 @@ export interface OpenClawConfig {
   agents: { defaults: { model: { primary: string; fallbacks?: string[] } } }
   models: { providers: { [provider: string]: { apiKey?: string; baseUrl?: string; api?: string } } }
   gateway?: {
+    bind?: string
     host?: string
-    auth?: { token?: string }
+    auth?: {
+      mode?: string
+      token?: string
+    }
     http?: {
       endpoints?: {
         responses?: {

--- a/src/main/specs/gke.test.ts
+++ b/src/main/specs/gke.test.ts
@@ -57,6 +57,8 @@ describe('gkeDeriver gateway injection', () => {
     const alphaConfig = getOpenClawConfig(files, 'alpha')
     const betaConfig = getOpenClawConfig(files, 'beta')
 
+    expect(alphaConfig.gateway?.bind).toBe('lan')
+    expect(alphaConfig.gateway?.auth?.mode).toBe('token')
     expect(typeof alphaConfig.gateway?.auth?.token).toBe('string')
     expect(alphaConfig.gateway.auth.token.length).toBeGreaterThan(0)
     expect(alphaConfig.gateway.auth.token).toBe(betaConfig.gateway.auth.token)

--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -70,12 +70,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
     envConfig: Record<string, unknown>,
     secrets?: DeriveSecrets
   ): Promise<SpecFile[]> {
-    const {
-      projectId,
-      clusterZone,
-      diskZone,
-      domain: envDomain,
-    } = envConfig as { projectId: string; clusterZone: string; diskZone?: string; domain?: string; gatewayMode?: 'port-forward' | 'ingress' }
+    const { domain: envDomain } = envConfig as { domain?: string }
     const namespace = spec.slug
     const mode = resolveGatewayMode(envConfig)
     const ingressDomain = mode === 'ingress' ? envDomain : undefined
@@ -182,9 +177,11 @@ const gkeDeriver: DeploymentSpecDeriver = {
         },
         gateway: {
           ...baseGateway,
+          bind: (baseGateway.bind as string | undefined) ?? 'lan',
           mode: 'local',
           auth: {
             ...((baseGateway.auth as Record<string, unknown> | undefined) ?? {}),
+            mode: ((((baseGateway.auth as Record<string, unknown> | undefined) ?? {}).mode) as string | undefined) ?? 'token',
             token: agentToken,
           },
           http: {


### PR DESCRIPTION
This updates generated GKE OpenClaw configs to bind the gateway on the LAN interface and set explicit token auth so inter-agent gateway calls can reach peer pods. It also extends the gateway config typing and adds coverage in the spec and GKE deriver tests for the generated bind/auth fields. Verification: ./node_modules/.bin/tsc --noEmit -p tsconfig.node.json --composite false and pnpm exec vitest run --config vitest.config.mts src/main/specs/gke.test.ts src/main/github/spec.test.ts.