### PR TITLE
docs: clarify agent gateway communication workflow

### DIFF
--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -243,6 +243,8 @@ export function generateAgentsMd(input: AgentsInput): string {
       '1. Read `TEAM.md` — it lists each teammate\'s `gateway` URL and the shared `gateway_token`',
       '2. Use the `exec` tool to run a curl POST to `<gateway>/v1/responses` (see `TOOLS.md` for the exact command)',
       '3. Include full context in your message so the recipient can act without asking follow-up questions',
+      '',
+      'IMPORTANT: Always copy the gateway URL exactly from `TEAM.md`. Never construct or guess URLs yourself.',
     )
   }
   if (input.hasTelegram) {


### PR DESCRIPTION
## Summary
Agents now have explicit, step-by-step instructions for inter-agent communication via the OpenClaw gateway HTTP API. The generated AGENTS.md and TOOLS.md files now clearly state that all agent-to-agent communication must use the gateway—never Telegram—and show exactly how to read TEAM.md to get gateway URLs and tokens.

## Changes
- **AGENTS.md generation**: Replaced passive instruction with mandatory 3-step workflow
- **TOOLS.md generation**: Added step-by-step section showing how to extract gateway info from TEAM.md before running curl
- **Clarity**: Explicit prohibition: "Telegram is for admin-to-agent communication only"

## Why This Matters
Previously agents (like Alice) would say "I don't have direct messaging capabilities" when asked to contact teammates. Now they'll understand they should read TEAM.md and use the exec+curl pattern to reach teammates via gateway.

🤖 Generated with Claude Code