### PR TITLE
feat: enable agents to install CLI tools at runtime

### DIFF
--- a/src/main/environments/gke/manifests.ts
+++ b/src/main/environments/gke/manifests.ts
@@ -128,6 +128,7 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
   const resourceName = `agent-${agentSlug}`
   const stateDir = '/agent-data/openclaw/state'
   const workspaceDir = '/agent-data/openclaw/workspace'
+  const toolsDir = '/agent-data/openclaw/tools'
 
   const volumes: unknown[] = [
     { name: 'agent-data', persistentVolumeClaim: { claimName: `${teamSlug}-agent-${agentSlug}` } },
@@ -142,7 +143,7 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
   ]
 
   const initSeedCmd = [
-    `mkdir -p ${stateDir} ${workspaceDir}`,
+    `mkdir -p ${stateDir} ${workspaceDir} ${toolsDir}/bin ${toolsDir}/cargo/bin`,
     `test -f ${workspaceDir}/BOOTSTRAP.md || cp /config/shared/BOOTSTRAP.md ${workspaceDir}/BOOTSTRAP.md`,
     `cp /config/shared/TEAM.md ${workspaceDir}/TEAM.md`,
     `test -f /config/shared/PROJECTS.md && cp /config/shared/PROJECTS.md ${workspaceDir}/PROJECTS.md || true`,
@@ -198,6 +199,12 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
             env: [
               { name: 'OPENCLAW_WORKSPACE_DIR', value: workspaceDir },
               { name: 'OPENCLAW_STATE_DIR', value: stateDir },
+              { name: 'NPM_CONFIG_PREFIX', value: toolsDir },
+              { name: 'PYTHONUSERBASE', value: toolsDir },
+              { name: 'PIP_USER', value: 'true' },
+              { name: 'GOPATH', value: toolsDir },
+              { name: 'CARGO_HOME', value: `${toolsDir}/cargo` },
+              { name: 'PATH', value: `${toolsDir}/bin:${toolsDir}/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` },
             ],
             ...(credentialSecretName ? { envFrom: [{ secretRef: { name: credentialSecretName } }] } : {}),
             volumeMounts: containerVolumeMounts,

--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -364,6 +364,20 @@ export function generateToolsMd(input: ToolsInput): string {
     )
   }
 
+  lines.push(
+    '',
+    '## Installing Tools',
+    'You can install tools directly — no sudo or elevated privileges needed.',
+    'All tools install to `/agent-data/openclaw/tools/` which is on your PATH and persists across restarts.',
+    '',
+    '| Manager | Command | Notes |',
+    '|---------|---------|-------|',
+    '| npm | `npm install -g <pkg>` | NPM_CONFIG_PREFIX is pre-configured |',
+    '| pip | `pip install <pkg>` | PIP_USER=true, installs to PYTHONUSERBASE |',
+    '| go | `go install <pkg>@latest` | GOPATH is set |',
+    '| cargo | `cargo install <pkg>` | CARGO_HOME is set |',
+  )
+
   lines.push('')
   return lines.join('\n')
 }

--- a/src/main/specs/bootstrap.ts
+++ b/src/main/specs/bootstrap.ts
@@ -5,6 +5,11 @@ export const DEFAULT_BOOTSTRAP_INSTRUCTIONS = `# Bootstrap Instructions
 - Check available disk space on /workspace
 
 ## Tool Installation
+- Tools install to /agent-data/openclaw/tools/ (on PATH, persists across restarts)
+- npm: \`npm install -g <package>\` (no sudo needed, NPM_CONFIG_PREFIX is set)
+- Python: \`pip install <package>\` (PIP_USER=true, installs to PYTHONUSERBASE)
+- Go: \`go install <package>@latest\` (GOPATH is set)
+- Cargo: \`cargo install <package>\` (CARGO_HOME is set)
 - Install project dependencies as defined in the team configuration
 - Configure git with the agent's identity (name and email from IDENTITY.md)
 


### PR DESCRIPTION
Agents can now install CLI tools at runtime without sudo. A persistent `/agent-data/openclaw/tools/` directory is created by the init container, with NPM_CONFIG_PREFIX, PYTHONUSERBASE, PIP_USER, GOPATH, CARGO_HOME, and PATH configured so npm/pip/go/cargo all install there. The generated TOOLS.md gains an "Installing Tools" section and bootstrap instructions are updated accordingly. All installs persist across pod restarts via the agent's PVC.