### PR TITLE
feat: enable apt package installation for agents

### DIFF
--- a/src/main/environments/gke/manifests.ts
+++ b/src/main/environments/gke/manifests.ts
@@ -195,6 +195,7 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
           containers: [{
             name: 'openclaw',
             image,
+            securityContext: { runAsUser: 0 },
             ports: [{ containerPort: 18789, name: 'gateway' }],
             env: [
               { name: 'OPENCLAW_WORKSPACE_DIR', value: workspaceDir },

--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -424,6 +424,7 @@ export function generateToolsMd(input: ToolsInput): string {
     '',
     '| Manager | Command | Notes |',
     '|---------|---------|-------|',
+    '| apt | `apt-get install -y <pkg>` | System packages, runs as root |',
     '| npm | `npm install -g <pkg>` | NPM_CONFIG_PREFIX is pre-configured |',
     '| pip | `pip install <pkg>` | PIP_USER=true, installs to PYTHONUSERBASE |',
     '| go | `go install <pkg>@latest` | GOPATH is set |',


### PR DESCRIPTION
## Summary
Agents can now install system packages using `apt-get` by running containers as root.

## Changes
- Set `securityContext.runAsUser: 0` on openclaw containers to enable root access
- Added `apt` to TOOLS.md installing tools documentation

Running as root in containers is standard for agent deployments requiring system-level package installation.