### PR TITLE
Require explicit mention for all agents in Telegram groups

### DIFF
--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -150,7 +150,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
               groupPolicy: 'allowlist',
               groupAllowFrom: [telegramAdminId!],
               groups: {
-                [telegramGroupId!]: { requireMention: agent.slug !== spec.leadAgent },
+                [telegramGroupId!]: { requireMention: true },
               },
               streaming: 'partial',
             },


### PR DESCRIPTION
## Summary
- Changed Telegram group config to require explicit @mention for all agents, including the lead agent
- Previously, lead agent responded to all messages; now all agents only respond when explicitly mentioned

## Impact
All team members must explicitly @mention agents to get their attention in group chats, reducing unnecessary responses and improving conversation clarity.