### PR TITLE
fix: remove Connect to OpenClaw CLI header and fix scrollability

### DIFF
--- a/src/renderer/src/components/agent/ConnectPane.tsx
+++ b/src/renderer/src/components/agent/ConnectPane.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Check, Copy, Terminal } from 'lucide-react'
+import { Check, Copy } from 'lucide-react'
 import { useEnvironment } from '../../hooks/useEnvironments'
 
 interface GkeConfig {
@@ -62,13 +62,8 @@ export function ConnectPane({ teamSlug, agentSlug, envSlug }: {
   const missing = !projectId || !clusterName || !clusterZone
 
   return (
-    <div className="flex-1 overflow-y-auto p-6">
+    <div className="h-full overflow-y-auto p-6">
       <div className="max-w-xl mx-auto space-y-6">
-        <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
-          <Terminal className="w-4 h-4" />
-          Connect to OpenClaw CLI
-        </div>
-
         <p className="text-sm text-gray-500">
           Access the OpenClaw CLI directly inside the running pod to configure models,
           channels, skills, and other settings not available in this app.


### PR DESCRIPTION
Remove the 'Connect to OpenClaw CLI' heading from the Connect tab for a cleaner UI. Also fix the panel scrollability by changing flex-1 to h-full so content properly overflows within the constrained parent container.