### PR TITLE
fix: disable save buttons when required fields are empty

### DIFF
--- a/src/renderer/src/components/AgentSpecPanel.tsx
+++ b/src/renderer/src/components/AgentSpecPanel.tsx
@@ -79,7 +79,7 @@ export function AgentSpecPanel({ teamSlug, agentSlug }: { teamSlug: string; agen
                 variant="primary"
                 size="sm"
                 onClick={() => void handleSave()}
-                disabled={saveTeam.isPending}
+                disabled={saveTeam.isPending || !agent.name.trim() || !agent.role.trim() || !agent.persona.trim() || agent.models.length === 0}
               >
                 {saveTeam.isPending ? 'Saving...' : 'Save'}
               </Button>

--- a/src/renderer/src/components/SpecEditor.tsx
+++ b/src/renderer/src/components/SpecEditor.tsx
@@ -142,7 +142,7 @@ export function SpecEditor({ spec, onSpecChange, isEditing, onEdit, onCancel, on
             variant="primary"
             size="sm"
             onClick={() => void onSave()}
-            disabled={isSaving}
+            disabled={isSaving || !spec.name.trim() || !spec.slug.trim()}
           >
             {isSaving ? 'Saving...' : 'Save'}
           </Button>

--- a/src/renderer/src/components/team/AgentCard.tsx
+++ b/src/renderer/src/components/team/AgentCard.tsx
@@ -269,45 +269,47 @@ export function AgentCard({
                 </div>
                 <div>
                   <Label>Token</Label>
-                  <div className="flex items-center gap-1.5">
-                    <Input
-                      mono
-                      type="password"
-                      value={telegramToken}
-                      onChange={(e) => setTelegramToken(e.target.value)}
-                      placeholder={tokenMasked ? 'Update token' : '123456:ABC...'}
-                    />
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      onClick={saveToken}
-                      disabled={tokenBusy || !teamSlug || !agent.slug}
-                      className="shrink-0"
-                    >
-                      Save
-                    </Button>
-                    {tokenMasked && (
+                  <div className="space-y-1.5">
+                    <div className="flex items-center gap-1.5">
+                      <Input
+                        mono
+                        type="password"
+                        value={telegramToken}
+                        onChange={(e) => setTelegramToken(e.target.value)}
+                        placeholder={tokenMasked ? 'Update token' : '123456:ABC...'}
+                      />
                       <Button
-                        variant="secondary"
+                        variant="primary"
                         size="sm"
-                        onClick={clearToken}
-                        disabled={tokenBusy}
+                        onClick={saveToken}
+                        disabled={tokenBusy || !teamSlug || !agent.slug}
                         className="shrink-0"
                       >
-                        Clear
+                        Save
                       </Button>
-                    )}
+                    </div>
                     {tokenMasked && (
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={syncAvatar}
-                        disabled={tokenBusy}
-                        className="shrink-0"
-                        title="Push agent avatar to Telegram bot profile photo"
-                      >
-                        Sync Avatar
-                      </Button>
+                      <div className="flex items-center gap-1.5">
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={clearToken}
+                          disabled={tokenBusy}
+                          className="shrink-0"
+                        >
+                          Clear
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={syncAvatar}
+                          disabled={tokenBusy}
+                          className="shrink-0"
+                          title="Push agent avatar to Telegram bot profile photo"
+                        >
+                          Sync Avatar
+                        </Button>
+                      </div>
                     )}
                   </div>
                   {tokenMasked && (


### PR DESCRIPTION
Adds validation to prevent saving incomplete agent and spec configurations.

- **AgentSpecPanel**: Save button disabled when agent name, role, persona are empty or no models selected
- **SpecEditor**: Save button disabled when spec name or slug are empty
- **AgentCard**: Restructured Telegram token UI into two-row layout for better readability