### PR TITLE
refactor: Split GCP settings into form and help panel

### DIFF
--- a/src/renderer/src/components/SettingsPage.tsx
+++ b/src/renderer/src/components/SettingsPage.tsx
@@ -4,8 +4,7 @@ import type { SettingsSection } from '../store/nav'
 import { useTeams } from '../hooks/useTeams'
 import { GeneralSettings } from './settings/GeneralSettings'
 import { OpenRouterSettings } from './settings/OpenRouterSettings'
-import { GkeSettings } from './settings/GkeSettings'
-import { MissionControlSettings } from './settings/MissionControlSettings'
+import { GkeSettings, GkeHelpPanel } from './settings/GkeSettings'
 import { SoulPatternsSettings } from './settings/SoulPatternsSettings'
 import { AgentPatternsSettings } from './settings/AgentPatternsSettings'
 import { LeadPatternsSettings } from './settings/LeadPatternsSettings'
@@ -16,8 +15,7 @@ const sections: Array<{ id: SettingsSection; label: string; group?: string }> = 
   { id: 'general', label: 'General' },
   { id: 'openrouter', label: 'OpenRouter' },
   { id: 'google-cloud', label: 'Google Cloud' },
-  { id: 'mission-control', label: 'Mission Control' },
-  { id: 'patterns-soul', label: 'Soul', group: 'Agent Patterns' },
+{ id: 'patterns-soul', label: 'Soul', group: 'Agent Patterns' },
   { id: 'patterns-agents', label: 'Behavior', group: 'Agent Patterns' },
   { id: 'patterns-lead', label: 'Team Lead', group: 'Agent Patterns' },
   { id: 'patterns-user', label: 'User', group: 'Agent Patterns' },
@@ -27,7 +25,6 @@ const sectionContent: Record<SettingsSection, () => JSX.Element> = {
   'general': GeneralSettings,
   'openrouter': OpenRouterSettings,
   'google-cloud': GkeSettings,
-  'mission-control': MissionControlSettings,
   'patterns-soul': SoulPatternsSettings,
   'patterns-agents': AgentPatternsSettings,
   'patterns-lead': LeadPatternsSettings,
@@ -38,7 +35,6 @@ const sectionTitles: Record<SettingsSection, string> = {
   'general': 'General',
   'openrouter': 'OpenRouter',
   'google-cloud': 'Google Cloud',
-  'mission-control': 'Mission Control',
   'patterns-soul': 'Soul Patterns',
   'patterns-agents': 'Agent Behavior Patterns',
   'patterns-lead': 'Team Lead Patterns',
@@ -114,6 +110,12 @@ export function SettingsPage() {
           <Content />
         </div>
       </div>
+
+      {settingsSection === 'google-cloud' && (
+        <div className="w-56 shrink-0 border-l border-gray-100 overflow-y-auto px-6 py-8">
+          <GkeHelpPanel />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/settings/GkeSettings.tsx
+++ b/src/renderer/src/components/settings/GkeSettings.tsx
@@ -98,99 +98,99 @@ export function GkeSettings() {
   }
 
   return (
-    <div className="flex gap-8">
-      <div className="w-40 shrink-0 space-y-4">
-        <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Setup Guide</p>
-        {GUIDE_STEPS.map((s) => (
-          <div key={s.title} className="space-y-1">
-            <p className="text-xs font-medium text-gray-700">{s.title}</p>
-            <p className="text-xs text-gray-500 leading-relaxed">{s.desc}</p>
-            <a href={s.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700">
-              Open <ExternalLink className="w-3 h-3" />
-            </a>
-          </div>
-        ))}
-      </div>
-
-      <div className="flex-1 space-y-3">
-        <div className="flex items-start justify-between gap-4">
-          <p className="text-xs text-gray-500">Configure your GKE cluster for agent deployment.</p>
-          {authStatus?.authenticated ? (
-            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-green-700 bg-green-50 px-2.5 py-1 rounded-full shrink-0">
-              <Check className="w-3 h-3" /> Authenticated
-            </span>
-          ) : gkeConfig ? (
-            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-amber-700 bg-amber-50 px-2.5 py-1 rounded-full shrink-0">
-              <X className="w-3 h-3" /> Not authenticated
-            </span>
-          ) : (
-            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 bg-gray-100 px-2.5 py-1 rounded-full shrink-0">
-              <X className="w-3 h-3" /> Not configured
-            </span>
-          )}
-        </div>
-
-        <div>
-          <Label>GCP Project ID</Label>
-          <Input mono value={form.projectId} onChange={(e) => updateField('projectId', e.target.value)} placeholder="my-gcp-project" />
-        </div>
-
-        <div className="grid grid-cols-3 gap-3">
-          <div>
-            <Label>Cluster name</Label>
-            <Input mono value={form.clusterName} onChange={(e) => updateField('clusterName', e.target.value)} placeholder="coordina-cluster" />
-          </div>
-          <div>
-            <Label>Cluster location</Label>
-            <Input mono value={form.clusterZone} onChange={(e) => updateField('clusterZone', e.target.value)} placeholder="us-central1" />
-          </div>
-          <div>
-            <Label>Disk zone</Label>
-            <Input mono value={form.diskZone} onChange={(e) => updateField('diskZone', e.target.value)} placeholder="us-central1-a" />
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <Label>Gateway mode</Label>
-            <Select mono value={form.gatewayMode} onChange={(e) => updateField('gatewayMode', e.target.value)}>
-              <option value="port-forward">Port-forward (no domain)</option>
-              <option value="ingress">Ingress (domain + IAP)</option>
-            </Select>
-          </div>
-          <div>
-            <Label>Base domain</Label>
-            <Input mono value={form.domain} onChange={(e) => updateField('domain', e.target.value)} placeholder="example.com" disabled={form.gatewayMode !== 'ingress'} />
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <Label>OAuth Client ID</Label>
-            <Input mono value={form.clientId} onChange={(e) => updateField('clientId', e.target.value)} placeholder="0123456789-abc.apps.googleusercontent.com" />
-          </div>
-          <div>
-            <Label>OAuth Client Secret</Label>
-            <Input mono type="password" value={form.clientSecret} onChange={(e) => updateField('clientSecret', e.target.value)} />
-          </div>
-        </div>
-
-        {formError && (
-          <div className="flex items-center gap-2 text-xs text-red-600">
-            <AlertCircle className="w-3.5 h-3.5" />
-            {formError}
-          </div>
+    <div className="space-y-3">
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-xs text-gray-500">Configure your GKE cluster for agent deployment.</p>
+        {authStatus?.authenticated ? (
+          <span className="inline-flex items-center gap-1.5 text-xs font-medium text-green-700 bg-green-50 px-2.5 py-1 rounded-full shrink-0">
+            <Check className="w-3 h-3" /> Authenticated
+          </span>
+        ) : gkeConfig ? (
+          <span className="inline-flex items-center gap-1.5 text-xs font-medium text-amber-700 bg-amber-50 px-2.5 py-1 rounded-full shrink-0">
+            <X className="w-3 h-3" /> Not authenticated
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 bg-gray-100 px-2.5 py-1 rounded-full shrink-0">
+            <X className="w-3 h-3" /> Not configured
+          </span>
         )}
-
-        <div className="flex items-center gap-3">
-          <Button variant="primary" size="sm" onClick={() => void handleSave()} disabled={saveConfig.isPending}>
-            {saveConfig.isPending ? 'Saving...' : saved ? 'Saved' : 'Save'}
-          </Button>
-          <Button variant="secondary" size="sm" onClick={() => void handleAuth()} disabled={authState === 'authing' || saveConfig.isPending}>
-            {authState === 'authing' ? 'Signing in...' : 'Sign in with Google'}
-          </Button>
-        </div>
       </div>
+
+      <div>
+        <Label>GCP Project ID</Label>
+        <Input mono value={form.projectId} onChange={(e) => updateField('projectId', e.target.value)} placeholder="my-gcp-project" />
+      </div>
+
+      <div>
+        <Label>Cluster name</Label>
+        <Input mono value={form.clusterName} onChange={(e) => updateField('clusterName', e.target.value)} placeholder="coordina-cluster" />
+      </div>
+
+      <div>
+        <Label>Cluster location</Label>
+        <Input mono value={form.clusterZone} onChange={(e) => updateField('clusterZone', e.target.value)} placeholder="us-central1" />
+      </div>
+
+      <div>
+        <Label>Disk zone</Label>
+        <Input mono value={form.diskZone} onChange={(e) => updateField('diskZone', e.target.value)} placeholder="us-central1-a" />
+      </div>
+
+      <div>
+        <Label>Gateway mode</Label>
+        <Select mono value={form.gatewayMode} onChange={(e) => updateField('gatewayMode', e.target.value)}>
+          <option value="port-forward">Port-forward (no domain)</option>
+          <option value="ingress">Ingress (domain + IAP)</option>
+        </Select>
+      </div>
+
+      <div>
+        <Label>Base domain</Label>
+        <Input mono value={form.domain} onChange={(e) => updateField('domain', e.target.value)} placeholder="example.com" disabled={form.gatewayMode !== 'ingress'} />
+      </div>
+
+      <div>
+        <Label>OAuth Client ID</Label>
+        <Input mono value={form.clientId} onChange={(e) => updateField('clientId', e.target.value)} placeholder="0123456789-abc.apps.googleusercontent.com" />
+      </div>
+
+      <div>
+        <Label>OAuth Client Secret</Label>
+        <Input mono type="password" value={form.clientSecret} onChange={(e) => updateField('clientSecret', e.target.value)} />
+      </div>
+
+      {formError && (
+        <div className="flex items-center gap-2 text-xs text-red-600">
+          <AlertCircle className="w-3.5 h-3.5" />
+          {formError}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button variant="primary" size="sm" onClick={() => void handleSave()} disabled={saveConfig.isPending}>
+          {saveConfig.isPending ? 'Saving...' : saved ? 'Saved' : 'Save'}
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => void handleAuth()} disabled={authState === 'authing' || saveConfig.isPending}>
+          {authState === 'authing' ? 'Signing in...' : 'Sign in with Google'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function GkeHelpPanel() {
+  return (
+    <div className="space-y-5">
+      <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Setup Guide</p>
+      {GUIDE_STEPS.map((s) => (
+        <div key={s.title} className="space-y-1">
+          <p className="text-xs font-medium text-gray-700">{s.title}</p>
+          <p className="text-xs text-gray-500 leading-relaxed">{s.desc}</p>
+          <a href={s.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700">
+            Open <ExternalLink className="w-3 h-3" />
+          </a>
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/renderer/src/store/nav.ts
+++ b/src/renderer/src/store/nav.ts
@@ -8,7 +8,7 @@ export type SelectedItem =
 
 export type ContentTab = 'deploy' | 'spec' | 'files' | 'connect'
 
-export type SettingsSection = 'general' | 'openrouter' | 'google-cloud' | 'mission-control' | 'patterns-soul' | 'patterns-agents' | 'patterns-lead' | 'patterns-user'
+export type SettingsSection = 'general' | 'openrouter' | 'google-cloud' | 'patterns-soul' | 'patterns-agents' | 'patterns-lead' | 'patterns-user'
 
 interface NavStore {
   selectedItem: SelectedItem | null


### PR DESCRIPTION
## Summary
- Reorganized Google Cloud settings: form takes full content area, help panel moved to dedicated right side panel
- All form fields now display on individual rows for better readability
- Unified max-width constraint across all settings pages
- Removed unused Mission Control settings section

The new layout provides clearer separation between the configuration form and setup guidance, making the interface more focused and easier to navigate.