### PR TITLE
refactor: Convert agent patterns to multi-line textarea input

### DIFF
--- a/src/renderer/src/components/settings/AgentPatternsSettings.tsx
+++ b/src/renderer/src/components/settings/AgentPatternsSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Input, Label, Button } from '../ui'
+import { Input, Label } from '../ui'
 import {
   SectionTextarea, SaveBar, usePatterns,
   toTextarea, cleanTextarea, cleanString, cleanObj,
@@ -48,12 +48,7 @@ export function AgentPatternsSettings() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <p className="text-xs text-gray-500">Rules and instructions injected into AGENTS.md for every agent.</p>
-        <Button variant="ghost" size="sm" onClick={handleReset} className="text-gray-400 hover:text-gray-600">
-          Reset to defaults
-        </Button>
-      </div>
+      <p className="text-xs text-gray-500">Rules and instructions injected into AGENTS.md for every agent.</p>
       <div>
         <Label>First Run</Label>
         <Input value={firstRun} onChange={(e) => setFirstRun(e.target.value)} />
@@ -65,7 +60,7 @@ export function AgentPatternsSettings() {
         <Label>Default Rule</Label>
         <Input value={defaultRule} onChange={(e) => setDefaultRule(e.target.value)} />
       </div>
-      <SaveBar onSave={handleSave} isPending={saveSettings.isPending} saved={saved} />
+      <SaveBar onSave={handleSave} isPending={saveSettings.isPending} saved={saved} onReset={handleReset} />
     </div>
   )
 }

--- a/src/renderer/src/components/settings/LeadPatternsSettings.tsx
+++ b/src/renderer/src/components/settings/LeadPatternsSettings.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react'
-import { Button } from '../ui'
 import {
   SectionTextarea, SaveBar, usePatterns,
   toTextarea, cleanTextarea, cleanObj,
@@ -34,14 +33,9 @@ export function LeadPatternsSettings() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <p className="text-xs text-gray-500">Responsibilities injected into AGENTS.md for agents marked as team lead.</p>
-        <Button variant="ghost" size="sm" onClick={handleReset} className="text-gray-400 hover:text-gray-600">
-          Reset to defaults
-        </Button>
-      </div>
+      <p className="text-xs text-gray-500">Responsibilities injected into AGENTS.md for agents marked as team lead.</p>
       <SectionTextarea label="Responsibilities" value={responsibilities} onChange={setResponsibilities} />
-      <SaveBar onSave={handleSave} isPending={saveSettings.isPending} saved={saved} />
+      <SaveBar onSave={handleSave} isPending={saveSettings.isPending} saved={saved} onReset={handleReset} />
     </div>
   )
 }

--- a/src/renderer/src/components/settings/SoulPatternsSettings.tsx
+++ b/src/renderer/src/components/settings/SoulPatternsSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Input, Label, Button } from '../ui'
+import { Input, Label } from '../ui'
 import {
   SectionTextarea, SaveBar, usePatterns,
   toTextarea, cleanTextarea, cleanString, cleanObj,
@@ -32,18 +32,13 @@ export function SoulPatternsSettings() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <p className="text-xs text-gray-500">Core truths and continuity instructions injected into SOUL.md.</p>
-        <Button variant="ghost" size="sm" onClick={handleReset} className="text-gray-400 hover:text-gray-600">
-          Reset to defaults
-        </Button>
-      </div>
+      <p className="text-xs text-gray-500">Core truths and continuity instructions injected into SOUL.md.</p>
       <SectionTextarea label="Core Truths" value={coreTruths} onChange={setCoreTruths} />
       <div>
         <Label>Continuity</Label>
         <Input value={continuity} onChange={(e) => setContinuity(e.target.value)} />
       </div>
-      <SaveBar onSave={handleSave} isPending={saveSettings.isPending} saved={saved} />
+      <SaveBar onSave={handleSave} isPending={saveSettings.isPending} saved={saved} onReset={handleReset} />
     </div>
   )
 }

--- a/src/renderer/src/components/settings/UserPatternsSettings.tsx
+++ b/src/renderer/src/components/settings/UserPatternsSettings.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react'
-import { Button } from '../ui'
 import {
   SectionTextarea, SaveBar, usePatterns,
   toTextarea, cleanTextarea, cleanObj,
@@ -31,14 +30,9 @@ export function UserPatternsSettings() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <p className="text-xs text-gray-500">Intro text injected into USER.md for every agent.</p>
-        <Button variant="ghost" size="sm" onClick={handleReset} className="text-gray-400 hover:text-gray-600">
-          Reset to defaults
-        </Button>
-      </div>
+      <p className="text-xs text-gray-500">Intro text injected into USER.md for every agent.</p>
       <SectionTextarea label="Intro Lines" value={introLines} onChange={setIntroLines} />
-      <SaveBar onSave={handleSave} isPending={saveSettings.isPending} saved={saved} />
+      <SaveBar onSave={handleSave} isPending={saveSettings.isPending} saved={saved} onReset={handleReset} />
     </div>
   )
 }

--- a/src/renderer/src/components/settings/pattern-utils.tsx
+++ b/src/renderer/src/components/settings/pattern-utils.tsx
@@ -106,17 +106,26 @@ export function SaveBar({
   onSave,
   isPending,
   saved,
+  onReset,
 }: {
   onSave: () => void
   isPending: boolean
   saved: boolean
+  onReset?: () => void
 }) {
   return (
     <div className="space-y-2 pt-4">
-      <Button variant="primary" size="lg" onClick={onSave} disabled={isPending}>
-        {isPending ? 'Saving...' : saved ? 'Saved' : 'Save changes'}
-      </Button>
-      <p className="text-xs text-gray-400">Re-derive your team for changes to take effect.</p>
+      <div className="flex items-center gap-3">
+        <Button variant="primary" size="lg" onClick={onSave} disabled={isPending}>
+          {isPending ? 'Saving...' : saved ? 'Saved' : 'Save changes'}
+        </Button>
+        {onReset && (
+          <Button variant="ghost" size="sm" onClick={onReset} className="text-gray-400 hover:text-gray-600">
+            Reset to defaults
+          </Button>
+        )}
+      </div>
+      <p className="text-xs text-gray-400">Re-deploy your team for changes to take effect.</p>
     </div>
   )
 }

--- a/src/shared/derivationDefaults.ts
+++ b/src/shared/derivationDefaults.ts
@@ -1,11 +1,11 @@
 import type { DerivationPatterns } from './types'
 
 export const DEFAULT_CORE_TRUTHS: string[] = [
-  'Be genuinely helpful, not performatively helpful',
-  'Have real opinions and share them when relevant',
-  'Be resourceful — try before asking',
-  'Earn trust through competence, not compliance',
-  'Remember you are a guest in the user\'s environment',
+  'Be genuinely helpful, not performatively helpful.',
+  'Have real opinions and share them when relevant.',
+  'Be resourceful — try before asking.',
+  'Earn trust through competence, not compliance.',
+  'Remember you are a guest in the user\'s environment.',
 ]
 
 export const DEFAULT_CONTINUITY = 'Files are your memory. Read and update them.'
@@ -13,29 +13,29 @@ export const DEFAULT_CONTINUITY = 'Files are your memory. Read and update them.'
 export const DEFAULT_FIRST_RUN = 'If `BOOTSTRAP.md` exists in the workspace, follow it and delete it when done.'
 
 export const DEFAULT_MEMORY_RULES: string[] = [
-  'Write daily logs to `memory/YYYY-MM-DD.md`',
-  'Promote important facts into `MEMORY.md`',
+  'Write daily logs to `memory/YYYY-MM-DD.md`.',
+  'Promote important facts into `MEMORY.md`.',
 ]
 
 export const DEFAULT_SAFETY_RULES: string[] = [
-  'Never exfiltrate data outside approved channels',
-  'Use `trash` over `rm` when available',
-  'Ask before taking external actions (sending messages, making purchases, etc.)',
+  'Never exfiltrate data outside approved channels.',
+  'Use `trash` over `rm` when available.',
+  'Ask before taking external actions (sending messages, making purchases, etc.).',
 ]
 
 export const DEFAULT_PRIORITIES: string[] = [
-  'Complete assigned tasks thoroughly before starting new ones',
-  'Communicate status updates to teammates proactively',
-  'Ask for clarification rather than making assumptions',
+  'Complete assigned tasks thoroughly before starting new ones.',
+  'Communicate status updates to teammates proactively.',
+  'Ask for clarification rather than making assumptions.',
 ]
 
 export const DEFAULT_TEAM_LEAD_RESPONSIBILITIES: string[] = [
-  'Coordinate work across the team: assign tasks, track progress, unblock teammates',
-  'Be the primary point of contact between the admin and the team',
-  'Delegate clearly: specify what to do, expected output, and deadline when assigning tasks',
-  'Proactively check in with teammates rather than waiting for them to report',
-  'When the admin gives direction, translate it into concrete tasks for the team',
-  'You have authority to set team priorities — teammates are expected to follow your assignments',
+  'Coordinate work across the team: assign tasks, track progress, unblock teammates.',
+  'Be the primary point of contact between the admin and the team.',
+  'Delegate clearly: specify what to do, expected output, and deadline when assigning tasks.',
+  'Proactively check in with teammates rather than waiting for them to report.',
+  'When the admin gives direction, translate it into concrete tasks for the team.',
+  'You have authority to set team priorities — teammates are expected to follow your assignments.',
 ]
 
 export const DEFAULT_RULE = 'Always verify your understanding before executing complex tasks'


### PR DESCRIPTION
Simplifies the pattern settings UI by replacing per-item inputs with a single multi-line textarea per section, where each line represents an item. Removes the + button and per-item delete UI controls. Affects all four pattern settings: Agent (Memory Rules, Safety Rules, Priorities), Lead (Responsibilities), Soul (Core Truths), and User (Intro Lines).