### PR TITLE
feat: Add OpenClaw logging.level config and GKE centralized logging

### DIFF
--- a/src/main/environments/gke/gcloud.ts
+++ b/src/main/environments/gke/gcloud.ts
@@ -174,7 +174,7 @@ export function listGcpZones(projectId: string, region?: string): Promise<{ name
 export function createAutopilotCluster(projectId: string, name: string, location: string): Promise<void> {
   return new Promise((resolve, reject) => {
     let stderr = ''
-    const child = spawn('gcloud', ['container', 'clusters', 'create-auto', name, `--project=${projectId}`, `--location=${location}`], {
+    const child = spawn('gcloud', ['container', 'clusters', 'create-auto', name, `--project=${projectId}`, `--location=${location}`, '--logging=SYSTEM,WORKLOAD'], {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
     child.stderr?.on('data', (d: Buffer) => { stderr += d.toString() })

--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -90,7 +90,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
     envConfig: Record<string, unknown>,
     secrets?: DeriveSecrets
   ): Promise<SpecFile[]> {
-    const { domain: envDomain } = envConfig as { domain?: string }
+    const { domain: envDomain, logLevel } = envConfig as { domain?: string; logLevel?: string }
     const namespace = spec.slug
     const mode = resolveGatewayMode(envConfig)
     const ingressDomain = mode === 'ingress' ? envDomain : undefined
@@ -207,6 +207,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
       const baseTools = (openclawConfig as { tools?: Record<string, unknown> }).tools ?? {}
       const openclawConfigWithGateway = {
         ...openclawConfig,
+        logging: { level: logLevel ?? 'info' },
         agents: {
           ...baseAgents,
           defaults: {

--- a/src/renderer/src/components/settings/GkeSettings.tsx
+++ b/src/renderer/src/components/settings/GkeSettings.tsx
@@ -35,11 +35,12 @@ interface GkeForm {
   clientSecret: string
   gatewayMode: 'port-forward' | 'ingress'
   domain: string
+  logLevel: 'debug' | 'info' | 'warn' | 'error'
 }
 
 const emptyGke = (): GkeForm => ({
   projectId: '', clusterZone: 'us-central1', diskZone: 'us-central1-a',
-  clientId: '', clientSecret: '', gatewayMode: 'port-forward', domain: '',
+  clientId: '', clientSecret: '', gatewayMode: 'port-forward', domain: '', logLevel: 'info',
 })
 
 function validateForm(form: GkeForm): string | null {
@@ -93,6 +94,7 @@ export function GkeSettings() {
         clientSecret: c.clientSecret ?? '',
         gatewayMode: (c.gatewayMode as 'port-forward' | 'ingress') ?? 'port-forward',
         domain: c.domain ?? '',
+        logLevel: (c.logLevel as 'debug' | 'info' | 'warn' | 'error') ?? 'info',
       })
     }
   }, [gkeConfig])
@@ -113,6 +115,7 @@ export function GkeSettings() {
     clientSecret: form.clientSecret,
     gatewayMode: form.gatewayMode,
     domain: form.gatewayMode === 'ingress' ? (form.domain || undefined) : undefined,
+    logLevel: form.logLevel,
   })
 
   const handleSave = async () => {
@@ -276,6 +279,20 @@ export function GkeSettings() {
           <Input mono value={form.domain} onChange={(e) => updateField('domain', e.target.value)} placeholder="example.com" />
         </div>
       )}
+
+      <hr className="border-gray-200" />
+      <h4 className="text-sm font-semibold text-gray-900 mb-1">Logging</h4>
+
+      <div>
+        <Label>OpenClaw log level</Label>
+        <Select mono value={form.logLevel} onChange={(e) => updateField('logLevel', e.target.value)}>
+          <option value="debug">debug</option>
+          <option value="info">info</option>
+          <option value="warn">warn</option>
+          <option value="error">error</option>
+        </Select>
+        <p className="text-xs text-gray-400 italic mt-1">Controls the logging.level written to each agent's openclaw.json. Agent logs are shipped to GCP Cloud Logging automatically.</p>
+      </div>
 
       {formError && (
         <div className="flex items-center gap-2 text-xs text-red-600">


### PR DESCRIPTION
## Summary
- Add OpenClaw logging.level setting to GKE settings UI with options: debug, info (default), warn, error
- Inject logging.level into each agent's openclaw.json configuration for consistent log verbosity control
- Enable GCP Cloud Logging explicitly on GKE cluster creation with --logging=SYSTEM,WORKLOAD to ensure container logs are shipped to Cloud Logging

## Changes
**GkeSettings.tsx**: Added logLevel field (type-safe union of log levels) to form interface, load/save logic, and new Logging section in UI with dropdown selector and explanatory text.

**gke.ts**: Destructure logLevel from envConfig and inject `logging: { level: logLevel ?? 'info' }` into the generated openclaw.json for each agent.

**gcloud.ts**: Add --logging=SYSTEM,WORKLOAD flag to createAutopilotCluster gcloud command to explicitly enable centralized logging for container workloads.