### PR TITLE
feat: Enable GKE agents to self-diagnose deployment

### DIFF
--- a/src/main/environments/gke/manifests.test.ts
+++ b/src/main/environments/gke/manifests.test.ts
@@ -70,6 +70,29 @@ describe('generateAgentStatefulSet', () => {
     expect(manifest).toContain('fsGroup: 1000')
     expect(manifest).toContain('fsGroupChangePolicy: OnRootMismatch')
   })
+
+  it('includes Downward API env vars (K8S_POD_NAME, K8S_NAMESPACE, K8S_NODE_NAME, K8S_POD_IP, K8S_CPU_REQUEST, K8S_CPU_LIMIT)', () => {
+    const manifest = generateAgentStatefulSet({ teamSlug: 'eng-alpha', agentSlug: 'alice' })
+    expect(manifest).toContain('K8S_POD_NAME')
+    expect(manifest).toContain('metadata.name')
+    expect(manifest).toContain('K8S_NAMESPACE')
+    expect(manifest).toContain('metadata.namespace')
+    expect(manifest).toContain('K8S_NODE_NAME')
+    expect(manifest).toContain('spec.nodeName')
+    expect(manifest).toContain('K8S_POD_IP')
+    expect(manifest).toContain('status.podIP')
+    expect(manifest).toContain('K8S_CPU_REQUEST')
+    expect(manifest).toContain('K8S_CPU_LIMIT')
+    expect(manifest).toContain('requests.cpu')
+    expect(manifest).toContain('limits.cpu')
+  })
+
+  it('init container copies ENV.md when present in ConfigMap', () => {
+    const manifest = generateAgentStatefulSet({ teamSlug: 'eng-alpha', agentSlug: 'alice' })
+    expect(manifest).toContain('ENV.md')
+    expect(manifest).toContain('/config/agent/ENV.md')
+    expect(manifest).toContain('/agent-data/openclaw/workspace/ENV.md')
+  })
 })
 
 describe('generateIapBackendConfig', () => {
@@ -164,6 +187,40 @@ describe('generateAgentConfigMap', () => {
     expect(yaml).toContain('AGENTS.md: |')
     expect(yaml).toContain('USER.md: |')
     expect(yaml).toContain('TOOLS.md: |')
+  })
+
+  it('includes ENV.md when provided', () => {
+    const yaml = generateAgentConfigMap({
+      teamSlug: 'alpha',
+      agentSlug: 'alice',
+      namespace: 'team-alpha',
+      identityMd: '# Identity',
+      soulMd: '# Soul',
+      skillsMd: '# Skills',
+      agentsMd: '# Agents',
+      userMd: '# User',
+      toolsMd: '# Tools',
+      openclawJson: '{}',
+      envMd: '# Deployment Environment\n\n## Cluster\n- GCP Project: my-proj',
+    })
+    expect(yaml).toContain('ENV.md: |')
+    expect(yaml).toContain('Deployment Environment')
+  })
+
+  it('omits ENV.md when not provided', () => {
+    const yaml = generateAgentConfigMap({
+      teamSlug: 'alpha',
+      agentSlug: 'alice',
+      namespace: 'team-alpha',
+      identityMd: '# Identity',
+      soulMd: '# Soul',
+      skillsMd: '# Skills',
+      agentsMd: '# Agents',
+      userMd: '# User',
+      toolsMd: '# Tools',
+      openclawJson: '{}',
+    })
+    expect(yaml).not.toContain('ENV.md:')
   })
 })
 

--- a/src/main/environments/gke/manifests.ts
+++ b/src/main/environments/gke/manifests.ts
@@ -61,13 +61,14 @@ export function generateAgentConfigMap(input: {
   userMd: string
   toolsMd: string
   openclawJson: string
+  envMd?: string
 }): string {
-  const { teamSlug, agentSlug, namespace, identityMd, soulMd, skillsMd, agentsMd, userMd, toolsMd, openclawJson } = input
+  const { teamSlug, agentSlug, namespace, identityMd, soulMd, skillsMd, agentsMd, userMd, toolsMd, openclawJson, envMd } = input
   return generateConfigMap({
     name: `${teamSlug}-${agentSlug}-config`,
     namespace,
     labels: { 'coordina.team': teamSlug, 'coordina.agent': agentSlug },
-    data: { 'IDENTITY.md': identityMd, 'SOUL.md': soulMd, 'SKILLS.md': skillsMd, 'AGENTS.md': agentsMd, 'USER.md': userMd, 'TOOLS.md': toolsMd, 'openclaw.json': openclawJson },
+    data: { 'IDENTITY.md': identityMd, 'SOUL.md': soulMd, 'SKILLS.md': skillsMd, 'AGENTS.md': agentsMd, 'USER.md': userMd, 'TOOLS.md': toolsMd, 'openclaw.json': openclawJson, ...(envMd ? { 'ENV.md': envMd } : {}) },
   })
 }
 
@@ -154,6 +155,7 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
     `cp /config/agent/AGENTS.md ${workspaceDir}/AGENTS.md`,
     `cp /config/agent/USER.md ${workspaceDir}/USER.md`,
     `cp /config/agent/TOOLS.md ${workspaceDir}/TOOLS.md`,
+    `test -f /config/agent/ENV.md && cp /config/agent/ENV.md ${workspaceDir}/ENV.md || true`,
     `cp /config/agent/openclaw.json ${stateDir}/openclaw.json`,
     'chown -R 1000:1000 /agent-data/openclaw',
     'chmod -R u+rwX,g+rwX /agent-data/openclaw',
@@ -206,6 +208,12 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
               { name: 'GOPATH', value: toolsDir },
               { name: 'CARGO_HOME', value: `${toolsDir}/cargo` },
               { name: 'PATH', value: `${toolsDir}/bin:${toolsDir}/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` },
+              { name: 'K8S_POD_NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
+              { name: 'K8S_NAMESPACE', valueFrom: { fieldRef: { fieldPath: 'metadata.namespace' } } },
+              { name: 'K8S_NODE_NAME', valueFrom: { fieldRef: { fieldPath: 'spec.nodeName' } } },
+              { name: 'K8S_POD_IP', valueFrom: { fieldRef: { fieldPath: 'status.podIP' } } },
+              { name: 'K8S_CPU_REQUEST', valueFrom: { resourceFieldRef: { resource: 'requests.cpu' } } },
+              { name: 'K8S_CPU_LIMIT', valueFrom: { resourceFieldRef: { resource: 'limits.cpu' } } },
             ],
             ...(credentialSecretName ? { envFrom: [{ secretRef: { name: credentialSecretName } }] } : {}),
             volumeMounts: containerVolumeMounts,

--- a/src/main/github/spec.test.ts
+++ b/src/main/github/spec.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateIdentityMd, generateSoulMd, generateOpenClawJson, generateSkillsMd, generateAgentsMd, generateTeamMd, generateUserMd, generateToolsMd } from './spec'
+import { generateIdentityMd, generateSoulMd, generateOpenClawJson, generateSkillsMd, generateAgentsMd, generateTeamMd, generateUserMd, generateToolsMd, generateEnvMd } from './spec'
 
 describe('generateIdentityMd', () => {
   it('outputs key-value format with Name and Creature', () => {
@@ -454,5 +454,94 @@ describe('generateTeamMd', () => {
     })
 
     expect(md).not.toContain('## Mission')
+  })
+})
+
+describe('generateEnvMd', () => {
+  it('outputs cluster, pod, and runtime variables sections', () => {
+    const md = generateEnvMd({
+      agentSlug: 'alice',
+      teamSlug: 'eng-alpha',
+      clusterName: 'eng-alpha',
+      clusterZone: 'us-central1-a',
+      projectId: 'my-gcp-project',
+      image: 'alpine/openclaw:latest',
+      diskGi: 10,
+      cpu: 1,
+      gatewayMode: 'port-forward',
+      namespace: 'eng-alpha',
+    })
+    expect(md).toContain('# Deployment Environment')
+    expect(md).toContain('## Cluster')
+    expect(md).toContain('GCP Project: my-gcp-project')
+    expect(md).toContain('Cluster: eng-alpha')
+    expect(md).toContain('Zone: us-central1-a')
+    expect(md).toContain('## Pod')
+    expect(md).toContain('Pod name: agent-alice-0')
+    expect(md).toContain('Image: alpine/openclaw:latest')
+    expect(md).toContain('CPU: 1 vCPU')
+    expect(md).toContain('Disk: 10Gi at /agent-data')
+    expect(md).toContain('Gateway port: 18789')
+    expect(md).toContain('Gateway mode: port-forward')
+    expect(md).toContain('## Runtime Variables')
+    expect(md).toContain('K8S_POD_NAME')
+    expect(md).toContain('K8S_NAMESPACE')
+    expect(md).toContain('K8S_NODE_NAME')
+    expect(md).toContain('K8S_POD_IP')
+    expect(md).toContain('K8S_CPU_REQUEST')
+    expect(md).toContain('K8S_CPU_LIMIT')
+  })
+})
+
+describe('generateToolsMd - Self-Diagnostics section', () => {
+  it('includes Self-Diagnostics heading and health checks', () => {
+    const md = generateToolsMd({ hasGateways: true })
+    expect(md).toContain('## Self-Diagnostics')
+    expect(md).toContain('Gateway health')
+    expect(md).toContain('curl -s http://127.0.0.1:18789/v1/version')
+    expect(md).toContain('Disk space')
+    expect(md).toContain('df -h /agent-data')
+    expect(md).toContain('Memory usage')
+    expect(md).toContain('cat /proc/meminfo | head -5')
+    expect(md).toContain('DNS resolution')
+    expect(md).toContain('nslookup kubernetes.default.svc.cluster.local')
+    expect(md).toContain('External network connectivity')
+    expect(md).toContain('curl -s -m 5 https://openrouter.ai/api/v1/models | head -c 100')
+    expect(md).toContain('Environment variables')
+    expect(md).toContain('env | grep -E "^(K8S_|OPENCLAW_|PATH)" | sort')
+  })
+
+  it('includes peer connectivity checks when peers provided', () => {
+    const md = generateToolsMd({
+      hasGateways: true,
+      peers: [
+        { slug: 'bob', gatewayUrl: 'http://agent-bob.team.svc.cluster.local:18789' },
+        { slug: 'charlie', gatewayUrl: 'http://agent-charlie.team.svc.cluster.local:18789' },
+      ],
+    })
+    expect(md).toContain('### Peer Connectivity')
+    expect(md).toContain('Check bob')
+    expect(md).toContain('curl -s -m 5 http://agent-bob.team.svc.cluster.local:18789/v1/version')
+    expect(md).toContain('Check charlie')
+    expect(md).toContain('curl -s -m 5 http://agent-charlie.team.svc.cluster.local:18789/v1/version')
+  })
+
+  it('shows "No peer agents configured" when peers list is empty', () => {
+    const md = generateToolsMd({
+      hasGateways: true,
+      peers: [],
+    })
+    expect(md).toContain('No peer agents configured.')
+  })
+
+  it('includes troubleshooting guide', () => {
+    const md = generateToolsMd({ hasGateways: true })
+    expect(md).toContain('### Troubleshooting')
+    expect(md).toContain('Gateway not responding')
+    expect(md).toContain('DNS failure')
+    expect(md).toContain('Disk full')
+    expect(md).toContain('Cannot reach peers')
+    expect(md).toContain('High memory')
+    expect(md).toContain('API errors')
   })
 })

--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -91,6 +91,21 @@ export interface ToolsInput {
   hasEmail?: boolean
   hasGitHub?: boolean
   githubUsername?: string
+  peers?: { slug: string; gatewayUrl: string }[]
+  namespace?: string
+}
+
+export interface EnvMdInput {
+  agentSlug: string
+  teamSlug: string
+  clusterName: string
+  clusterZone: string
+  projectId: string
+  image: string
+  diskGi: number
+  cpu: number
+  gatewayMode: string
+  namespace: string
 }
 
 export function generateIdentityMd(agent: AgentIdentity): string {
@@ -473,6 +488,86 @@ export function generateToolsMd(input: ToolsInput): string {
     '| cargo | `cargo install <pkg>` | CARGO_HOME is set |',
   )
 
+  lines.push(
+    '',
+    '## Self-Diagnostics',
+    'Run these commands to diagnose deployment problems. Use the `exec` tool.',
+    '',
+    '### Health Checks',
+    '```bash',
+    '# Gateway health',
+    'curl -s http://127.0.0.1:18789/v1/version',
+    '',
+    '# Disk space',
+    'df -h /agent-data',
+    '',
+    '# Memory usage',
+    'cat /proc/meminfo | head -5',
+    '',
+    '# DNS resolution',
+    'nslookup kubernetes.default.svc.cluster.local',
+    '',
+    '# External network connectivity',
+    'curl -s -m 5 https://openrouter.ai/api/v1/models | head -c 100',
+    '',
+    '# Environment variables',
+    'env | grep -E "^(K8S_|OPENCLAW_|PATH)" | sort',
+    '```',
+    '',
+    '### Peer Connectivity',
+  )
+  if (input.peers && input.peers.length > 0) {
+    lines.push('```bash')
+    for (const peer of input.peers) {
+      lines.push(`# Check ${peer.slug}`)
+      lines.push(`curl -s -m 5 ${peer.gatewayUrl}/v1/version`)
+    }
+    lines.push('```')
+  } else {
+    lines.push('No peer agents configured.')
+  }
+  lines.push(
+    '',
+    '### Troubleshooting',
+    '- **Gateway not responding**: Check if the process is running with `ps aux | grep openclaw`',
+    '- **DNS failure**: Cluster DNS may be down. Try `cat /etc/resolv.conf` and `ping 8.8.8.8`',
+    '- **Disk full**: Check with `df -h /agent-data`. Remove unnecessary files from `/agent-data/openclaw/workspace/`',
+    '- **Cannot reach peers**: Verify the peer pod is running. Check `K8S_NAMESPACE` matches expectations',
+    '- **High memory**: Check `cat /proc/meminfo` for MemAvailable. Restart may be needed if critically low',
+    '- **API errors**: Verify credentials with `env | grep OPENROUTER`. Check `curl -s https://openrouter.ai/api/v1/models -H "Authorization: Bearer $OPENROUTER_API_KEY" | head -c 200`',
+  )
+
   lines.push('')
+  return lines.join('\n')
+}
+
+export function generateEnvMd(input: EnvMdInput): string {
+  const lines: string[] = [
+    '# Deployment Environment',
+    '',
+    '## Cluster',
+    `- GCP Project: ${input.projectId}`,
+    `- Cluster: ${input.clusterName}`,
+    `- Zone: ${input.clusterZone}`,
+    `- Namespace: ${input.namespace}`,
+    '',
+    '## Pod',
+    `- Pod name: agent-${input.agentSlug}-0`,
+    `- Image: ${input.image}`,
+    `- CPU: ${input.cpu} vCPU`,
+    `- Disk: ${input.diskGi}Gi at /agent-data`,
+    '- Gateway port: 18789',
+    `- Gateway mode: ${input.gatewayMode}`,
+    '',
+    '## Runtime Variables',
+    'These environment variables are populated by the Kubernetes Downward API at runtime:',
+    '- `K8S_POD_NAME` - Actual pod name',
+    '- `K8S_NAMESPACE` - Kubernetes namespace',
+    '- `K8S_NODE_NAME` - Node the pod is scheduled on',
+    '- `K8S_POD_IP` - Pod cluster IP address',
+    '- `K8S_CPU_REQUEST` - CPU request',
+    '- `K8S_CPU_LIMIT` - CPU limit',
+    '',
+  ]
   return lines.join('\n')
 }

--- a/src/main/specs/bootstrap.ts
+++ b/src/main/specs/bootstrap.ts
@@ -1,8 +1,12 @@
 export const DEFAULT_BOOTSTRAP_INSTRUCTIONS = `# Bootstrap Instructions
 
 ## Environment Setup
-- Verify network connectivity and DNS resolution
-- Check available disk space on /workspace
+- Read ENV.md to understand your deployment context
+- Verify environment variables: \`env | grep -E "^(K8S_|OPENCLAW_)" | sort\`
+- Verify network connectivity: \`curl -s -m 5 https://openrouter.ai/api/v1/models | head -c 100\`
+- Check DNS resolution: \`nslookup kubernetes.default.svc.cluster.local\`
+- Check available disk space: \`df -h /agent-data\`
+- Verify gateway is healthy: \`curl -s http://127.0.0.1:18789/v1/version\`
 
 ## Tool Installation
 - Tools install to /agent-data/openclaw/tools/ (on PATH, persists across restarts)

--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -28,6 +28,7 @@ import {
   generateToolsMd,
   generateOpenClawJson,
   generateProjectsMd,
+  generateEnvMd,
 } from '../github/spec'
 
 import { deriveAgentEmail } from '../../shared/email'
@@ -90,7 +91,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
     envConfig: Record<string, unknown>,
     secrets?: DeriveSecrets
   ): Promise<SpecFile[]> {
-    const { domain: envDomain, logLevel } = envConfig as { domain?: string; logLevel?: string }
+    const { domain: envDomain, logLevel, projectId, clusterZone } = envConfig as { domain?: string; logLevel?: string; projectId?: string; clusterZone?: string }
     const namespace = spec.slug
     const mode = resolveGatewayMode(envConfig)
     const ingressDomain = mode === 'ingress' ? envDomain : undefined
@@ -305,6 +306,26 @@ const gkeDeriver: DeploymentSpecDeriver = {
         hasEmail,
         hasGitHub,
         githubUsername,
+        peers: spec.agents
+          .filter(a => a.slug !== agent.slug)
+          .map(a => ({
+            slug: a.slug,
+            gatewayUrl: `http://agent-${a.slug}.${namespace}.svc.cluster.local:18789`,
+          })),
+        namespace,
+      })
+      const effectiveImage = agent.image || spec.defaultImage || 'alpine/openclaw:latest'
+      const envMd = generateEnvMd({
+        agentSlug: agent.slug,
+        teamSlug: spec.slug,
+        clusterName: spec.slug,
+        clusterZone: clusterZone || 'unknown',
+        projectId: projectId || 'unknown',
+        image: effectiveImage,
+        diskGi: agent.diskGi ?? 10,
+        cpu: agent.cpu ?? 1,
+        gatewayMode: mode,
+        namespace,
       })
       const openclawJson = generateOpenClawJson(openclawConfigWithGateway)
       const agentConfigMap = generateAgentConfigMap({
@@ -318,6 +339,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
         userMd,
         toolsMd,
         openclawJson,
+        envMd,
       })
       const agentConfigHash = createHash('sha256').update(agentConfigMap).digest('hex')
 
@@ -328,6 +350,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
       files.push({ path: `agents/${agent.slug}/USER.md`, content: userMd })
       files.push({ path: `agents/${agent.slug}/TOOLS.md`, content: toolsMd })
       files.push({ path: `agents/${agent.slug}/openclaw.json`, content: openclawJson })
+      files.push({ path: `agents/${agent.slug}/ENV.md`, content: envMd })
       files.push({ path: `agents/${agent.slug}/configmap.yaml`, content: agentConfigMap })
       files.push({ path: `agents/${agent.slug}/statefulset.yaml`, content: generateAgentStatefulSet({
         teamSlug: spec.slug,


### PR DESCRIPTION
## Summary
Agents deployed on GKE can now self-diagnose their deployment environment and run health checks without external dependencies.

- Kubernetes Downward API env vars (K8S_POD_NAME, K8S_NAMESPACE, K8S_NODE_NAME, K8S_POD_IP, K8S_CPU_REQUEST, K8S_CPU_LIMIT) make pod/node/resource context available
- ENV.md documents cluster (project, cluster name, zone, namespace), pod (name, image, CPU, disk, gateway mode), and runtime variables
- Self-Diagnostics section in TOOLS.md with curl/bash commands for gateway health, disk space, DNS, external connectivity, peer reachability, and troubleshooting guide
- Bootstrap instructions updated to verify deployment environment on startup
- All changes use only Downward API (no RBAC required) and local shell commands

## Test plan
- ✅ manifests.test.ts: Downward API env vars present in StatefulSet, ENV.md seeded in init container
- ✅ spec.test.ts: generateEnvMd() outputs cluster/pod/runtime sections, Self-Diagnostics includes health checks and peer connectivity
- ✅ All 84 tests passing
- ✅ Full typecheck passing

Agents can now independently diagnose gateway issues, network problems, disk space constraints, DNS failures, and peer unreachability.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>