### PR TITLE
fix: guard selectItem against null on Settings back navigation

### DIFF
--- a/src/renderer/src/components/SettingsPage.tsx
+++ b/src/renderer/src/components/SettingsPage.tsx
@@ -68,7 +68,7 @@ export function SettingsPage() {
     if (teams?.length) {
       selectItem({ type: 'team', slug: teams[0].slug })
     } else {
-      selectItem(null as never)
+      selectItem(null)
     }
   }
 

--- a/src/renderer/src/store/nav.ts
+++ b/src/renderer/src/store/nav.ts
@@ -20,7 +20,7 @@ interface NavStore {
   deployingTeamSlug: string | null
   deployingAgentSlug: string | null
 
-  selectItem: (item: SelectedItem) => void
+  selectItem: (item: SelectedItem | null) => void
   setContentTab: (tab: ContentTab) => void
   toggleTeam: (slug: string) => void
   setSettingsSection: (section: SettingsSection) => void
@@ -43,6 +43,7 @@ export const useNav = create<NavStore>()(
       deployingAgentSlug: null,
 
       selectItem: (item) => set((s) => {
+        if (!item) return { selectedItem: null }
         const agentOnlyTabs: ContentTab[] = ['files', 'connect']
         const isTeam = item.type === 'team'
         const tabInvalid = isTeam && agentOnlyTabs.includes(s.contentTab)


### PR DESCRIPTION
## Summary
- When clicking "Back to app" from Settings with no teams loaded, `goBack()` called `selectItem(null as never)`, which crashed at `item.type` in the nav store
- Added null guard in `selectItem` and updated the type signature to accept `SelectedItem | null`
- Removed the `as never` type hack in `SettingsPage.tsx`

## Test plan
- [ ] Open Settings, click "Back to app" with no teams created — should not crash
- [ ] Open Settings, click "Back to app" with teams — should navigate to first team

🤖 Generated with [Claude Code](https://claude.com/claude-code)