### PR TITLE
feat: add memory configuration to agent pods

### DIFF
--- a/src/main/environments/gke/manifests.ts
+++ b/src/main/environments/gke/manifests.ts
@@ -1,4 +1,5 @@
 import yaml from 'js-yaml'
+import { DEFAULT_CPU, DEFAULT_MEMORY_GI, DEFAULT_DISK_GI } from '../../../shared/podDefaults'
 
 export function generateNamespace(name: string): string {
   return yaml.dump({ apiVersion: 'v1', kind: 'Namespace', metadata: { name } })
@@ -79,6 +80,7 @@ export interface AgentManifestInput {
   namespace?: string
   credentialSecretName?: string
   cpu?: number
+  memoryGi?: number
   podAnnotations?: Record<string, string>
 }
 
@@ -101,7 +103,7 @@ export function generateStorageClass(input: { teamSlug: string }): string {
 }
 
 export function generateAgentPvc(input: { teamSlug: string; agentSlug: string; namespace: string; diskGi?: number }): string {
-  const { teamSlug, agentSlug, namespace, diskGi = 10 } = input
+  const { teamSlug, agentSlug, namespace, diskGi = DEFAULT_DISK_GI } = input
   const name = `${teamSlug}-agent-${agentSlug}`
   const manifest = {
     apiVersion: 'v1',
@@ -124,6 +126,7 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
     namespace = 'default',
     credentialSecretName,
     cpu,
+    memoryGi,
     podAnnotations,
   } = input
   const resourceName = `agent-${agentSlug}`
@@ -214,10 +217,12 @@ export function generateAgentStatefulSet(input: AgentManifestInput): string {
               { name: 'K8S_POD_IP', valueFrom: { fieldRef: { fieldPath: 'status.podIP' } } },
               { name: 'K8S_CPU_REQUEST', valueFrom: { resourceFieldRef: { resource: 'requests.cpu' } } },
               { name: 'K8S_CPU_LIMIT', valueFrom: { resourceFieldRef: { resource: 'limits.cpu' } } },
+              { name: 'K8S_MEMORY_REQUEST', valueFrom: { resourceFieldRef: { resource: 'requests.memory' } } },
+              { name: 'K8S_MEMORY_LIMIT', valueFrom: { resourceFieldRef: { resource: 'limits.memory' } } },
             ],
             ...(credentialSecretName ? { envFrom: [{ secretRef: { name: credentialSecretName } }] } : {}),
             volumeMounts: containerVolumeMounts,
-            resources: { requests: { cpu: `${cpu ?? 1}` }, limits: { cpu: `${cpu ?? 1}` } },
+            resources: { requests: { cpu: `${cpu ?? DEFAULT_CPU}`, memory: `${memoryGi ?? DEFAULT_MEMORY_GI}Gi` }, limits: { cpu: `${cpu ?? DEFAULT_CPU}`, memory: `${memoryGi ?? DEFAULT_MEMORY_GI}Gi` } },
             readinessProbe: {
               exec: { command: ['node', '-e', "const s=require('net').createConnection(18789,'127.0.0.1',()=>{s.destroy();process.exit(0)});s.on('error',()=>process.exit(1))"] },
               initialDelaySeconds: 15,

--- a/src/main/github/spec.ts
+++ b/src/main/github/spec.ts
@@ -107,6 +107,7 @@ export interface EnvMdInput {
   image: string
   diskGi: number
   cpu: number
+  memoryGi: number
   gatewayMode: string
   namespace: string
 }
@@ -558,6 +559,7 @@ export function generateEnvMd(input: EnvMdInput): string {
     `- Pod name: agent-${input.agentSlug}-0`,
     `- Image: ${input.image}`,
     `- CPU: ${input.cpu} vCPU`,
+    `- Memory: ${input.memoryGi}Gi`,
     `- Disk: ${input.diskGi}Gi at /agent-data`,
     '- Gateway port: 18789',
     `- Gateway mode: ${input.gatewayMode}`,
@@ -570,6 +572,8 @@ export function generateEnvMd(input: EnvMdInput): string {
     '- `K8S_POD_IP` - Pod cluster IP address',
     '- `K8S_CPU_REQUEST` - CPU request',
     '- `K8S_CPU_LIMIT` - CPU limit',
+    '- `K8S_MEMORY_REQUEST` - Memory request',
+    '- `K8S_MEMORY_LIMIT` - Memory limit',
     '',
   ]
   return lines.join('\n')

--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -18,6 +18,7 @@ import {
   generateMcImagePullSecret,
 } from '../environments/gke/manifests'
 import type { MissionControlConfig } from '../../shared/types'
+import { DEFAULT_CPU, DEFAULT_MEMORY_GI, DEFAULT_DISK_GI } from '../../shared/podDefaults'
 import {
   generateTeamMd,
   generateIdentityMd,
@@ -323,8 +324,9 @@ const gkeDeriver: DeploymentSpecDeriver = {
         clusterZone: clusterZone || 'unknown',
         projectId: projectId || 'unknown',
         image: effectiveImage,
-        diskGi: agent.diskGi ?? 10,
-        cpu: agent.cpu ?? 1,
+        diskGi: agent.diskGi ?? DEFAULT_DISK_GI,
+        cpu: agent.cpu ?? DEFAULT_CPU,
+        memoryGi: agent.memoryGi ?? DEFAULT_MEMORY_GI,
         gatewayMode: mode,
         namespace,
       })
@@ -360,6 +362,7 @@ const gkeDeriver: DeploymentSpecDeriver = {
         namespace,
         credentialSecretName,
         cpu: agent.cpu,
+        memoryGi: agent.memoryGi,
         podAnnotations: {
           'coordina/shared-config-hash': teamConfigHash,
           'coordina/agent-config-hash': agentConfigHash,

--- a/src/main/validation/teamSpecNormalize.ts
+++ b/src/main/validation/teamSpecNormalize.ts
@@ -33,6 +33,7 @@ function normalizeAgent(agent: AgentSpec): AgentSpec {
       : (agent as unknown as { model?: string }).model ? [(agent as unknown as { model?: string }).model!.trim()].filter(Boolean) : [],
     image: normalizeOptional(agent.image),
     cpu: normalizePositiveNumber(agent.cpu),
+    memoryGi: normalizePositiveInt(agent.memoryGi),
     diskGi: normalizePositiveInt(agent.diskGi),
   }
 }
@@ -49,6 +50,7 @@ export function normalizeTeamSpec(spec: TeamSpec): TeamSpec {
     teamEmail: normalizeOptional(spec.teamEmail),
     defaultImage: normalizeOptional(spec.defaultImage),
     defaultCpu: normalizePositiveNumber(spec.defaultCpu),
+    defaultMemoryGi: normalizePositiveInt(spec.defaultMemoryGi),
     defaultDiskGi: normalizePositiveInt(spec.defaultDiskGi),
     leadAgent: normalizedLead && normalizedAgents.some(a => a.slug === normalizedLead) ? normalizedLead : undefined,
     startupInstructions: normalizeOptional(spec.startupInstructions),

--- a/src/renderer/src/components/AgentSpecPanel.tsx
+++ b/src/renderer/src/components/AgentSpecPanel.tsx
@@ -121,6 +121,7 @@ export function AgentSpecPanel({ teamSlug, agentSlug }: { teamSlug: string; agen
             isLead={agent.slug === localSpec.leadAgent}
             defaultImage={localSpec.defaultImage}
             defaultCpu={localSpec.defaultCpu}
+            defaultMemoryGi={localSpec.defaultMemoryGi}
             defaultDiskGi={localSpec.defaultDiskGi}
           />
         </div>

--- a/src/renderer/src/components/SpecEditor.tsx
+++ b/src/renderer/src/components/SpecEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { AlertCircle, Check, ExternalLink, Loader2, Pencil } from 'lucide-react'
 import type { TeamSpec } from '../../../shared/types'
+import { DEFAULT_CPU, DEFAULT_MEMORY_GI, DEFAULT_DISK_GI } from '../../../shared/podDefaults'
 import { Button, DialogShell, Input, Label, ReadField, Textarea } from './ui'
 
 export interface SpecEditorProps {
@@ -253,8 +254,9 @@ export function SpecEditor({ spec, onSpecChange, isEditing, onEdit, onCancel, on
           <div>
             <h4 className="text-sm font-semibold text-gray-900 mb-1">Resources</h4>
             <ReadField label="Container image" value={spec.defaultImage} defaultValue="alpine/openclaw:latest" />
-            <ReadField label="CPU (cores)" value={spec.defaultCpu} defaultValue={1} />
-            <ReadField label="Disk (Gi)" value={spec.defaultDiskGi} defaultValue={10} />
+            <ReadField label="CPU (cores)" value={spec.defaultCpu} defaultValue={DEFAULT_CPU} />
+            <ReadField label="Memory (Gi)" value={spec.defaultMemoryGi} defaultValue={DEFAULT_MEMORY_GI} />
+            <ReadField label="Disk (Gi)" value={spec.defaultDiskGi} defaultValue={DEFAULT_DISK_GI} />
           </div>
 
           <hr className="border-gray-200" />
@@ -513,7 +515,7 @@ export function SpecEditor({ spec, onSpecChange, isEditing, onEdit, onCancel, on
                 placeholder="ghcr.io/org/openclaw:latest"
               />
             </div>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-3 gap-3">
               <div>
                 <Label>CPU (cores)</Label>
                 <Input
@@ -522,7 +524,17 @@ export function SpecEditor({ spec, onSpecChange, isEditing, onEdit, onCancel, on
                   step={0.5}
                   value={spec.defaultCpu ?? ''}
                   onChange={(e) => set('defaultCpu')(e.target.value ? parseFloat(e.target.value) : undefined)}
-                  placeholder="1"
+                  placeholder={`${DEFAULT_CPU}`}
+                />
+              </div>
+              <div>
+                <Label>Memory (Gi)</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={spec.defaultMemoryGi ?? ''}
+                  onChange={(e) => set('defaultMemoryGi')(e.target.value ? parseInt(e.target.value, 10) : undefined)}
+                  placeholder={`${DEFAULT_MEMORY_GI}`}
                 />
               </div>
               <div>
@@ -532,7 +544,7 @@ export function SpecEditor({ spec, onSpecChange, isEditing, onEdit, onCancel, on
                   min={1}
                   value={spec.defaultDiskGi ?? ''}
                   onChange={(e) => set('defaultDiskGi')(e.target.value ? parseInt(e.target.value, 10) : undefined)}
-                  placeholder="10"
+                  placeholder={`${DEFAULT_DISK_GI}`}
                 />
               </div>
             </div>

--- a/src/renderer/src/components/team/AgentCard.tsx
+++ b/src/renderer/src/components/team/AgentCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { deriveAgentEmail } from '../../../../shared/email'
 import type { AgentSpec } from '../../../../shared/types'
+import { DEFAULT_CPU, DEFAULT_MEMORY_GI, DEFAULT_DISK_GI } from '../../../../shared/podDefaults'
 import { PERSONA_CATALOG, getPersonasByDivision } from '../../../../shared/personaCatalog'
 import { useModels } from '../../hooks/useModels'
 import { Button, Input, Label, ReadField, Select, Textarea } from '../ui'
@@ -15,6 +16,7 @@ interface Props {
   isLead?: boolean
   defaultImage?: string
   defaultCpu?: number
+  defaultMemoryGi?: number
   defaultDiskGi?: number
 }
 
@@ -27,6 +29,7 @@ export function AgentCard({
   isLead,
   defaultImage,
   defaultCpu,
+  defaultMemoryGi,
   defaultDiskGi,
 }: Props) {
   const { data: models } = useModels('openrouter')
@@ -340,7 +343,7 @@ export function AgentCard({
                     placeholder="—"
                   />
                 </div>
-                <div className="grid grid-cols-2 gap-3">
+                <div className="grid grid-cols-3 gap-3">
                   <div>
                     <Label>CPU (cores)</Label>
                     <Input
@@ -353,7 +356,22 @@ export function AgentCard({
                           e.target.value ? parseFloat(e.target.value) : undefined,
                         )
                       }
-                      placeholder={`${defaultCpu ?? 1}`}
+                      placeholder={`${defaultCpu ?? DEFAULT_CPU}`}
+                    />
+                  </div>
+                  <div>
+                    <Label>Memory (Gi)</Label>
+                    <Input
+                      type="number"
+                      min={1}
+                      step={1}
+                      value={agent.memoryGi ?? ''}
+                      onChange={(e) =>
+                        set('memoryGi')(
+                          e.target.value ? parseInt(e.target.value) : undefined,
+                        )
+                      }
+                      placeholder={`${defaultMemoryGi ?? DEFAULT_MEMORY_GI}`}
                     />
                   </div>
                   <div>
@@ -368,7 +386,7 @@ export function AgentCard({
                           e.target.value ? parseInt(e.target.value) : undefined,
                         )
                       }
-                      placeholder={`${defaultDiskGi ?? 10}`}
+                      placeholder={`${defaultDiskGi ?? DEFAULT_DISK_GI}`}
                     />
                   </div>
                 </div>
@@ -434,8 +452,9 @@ export function AgentCard({
             <div>
               <h4 className="text-sm font-semibold text-gray-900 mb-1">Resources</h4>
               <ReadField label="Container image" value={agent.image} defaultValue={defaultImage ?? 'alpine/openclaw:latest'} />
-              <ReadField label="CPU (cores)" value={agent.cpu} defaultValue={defaultCpu ?? 1} />
-              <ReadField label="Disk (Gi)" value={agent.diskGi} defaultValue={defaultDiskGi ?? 10} />
+              <ReadField label="CPU (cores)" value={agent.cpu} defaultValue={defaultCpu ?? DEFAULT_CPU} />
+              <ReadField label="Memory (Gi)" value={agent.memoryGi} defaultValue={defaultMemoryGi ?? DEFAULT_MEMORY_GI} />
+              <ReadField label="Disk (Gi)" value={agent.diskGi} defaultValue={defaultDiskGi ?? DEFAULT_DISK_GI} />
             </div>
           </>
         )}

--- a/src/shared/podDefaults.ts
+++ b/src/shared/podDefaults.ts
@@ -1,0 +1,5 @@
+// Default resource allocations for agent pods on GKE
+// FEATURE: Centralized pod resource defaults for team and agent config
+export const DEFAULT_CPU = 2
+export const DEFAULT_MEMORY_GI = 8
+export const DEFAULT_DISK_GI = 10

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,6 +22,7 @@ export interface AgentSpec {
   models: string[]
   image?: string
   cpu?: number
+  memoryGi?: number
   diskGi?: number
   tone?: string
   boundaries?: string[]
@@ -37,6 +38,7 @@ export interface TeamSpec {
   telegramAdminId?: string
   defaultImage?: string
   defaultCpu?: number
+  defaultMemoryGi?: number
   defaultDiskGi?: number
   leadAgent?: string
   startupInstructions?: string


### PR DESCRIPTION
Adds memory (Gi) resource allocation for agent pods with team-level and per-agent overrides. Defaults are centralized in podDefaults.ts (CPU: 2 cores, Memory: 8Gi, Disk: 10Gi). K8s StatefulSet now includes memory requests/limits and exposes K8S_MEMORY_REQUEST/LIMIT env vars. Updated UI with memory input fields in team spec editor and agent card. Memory is documented in generated ENV.md pod configuration.