### PR TITLE
feat: add JSON edit mode to team spec view with slug immutability validation

### DIFF
--- a/src/main/validation/teamSpec.ts
+++ b/src/main/validation/teamSpec.ts
@@ -1,26 +1,3 @@
 // Pure validation of team spec structure with model-level checks
 // FEATURE: Team spec validation module with zero side effects on output
-import { TeamSpec, ValidationResult, ValidationError } from '../../shared/types'
-
-export const validateTeamSpec = (
-  spec: TeamSpec
-): ValidationResult => {
-  const errors: ValidationError[] = []
-
-  if (!spec.name?.trim()) errors.push({ field: 'name', message: 'Team name is required' })
-  if (!spec.slug?.trim()) errors.push({ field: 'slug', message: 'Team slug is required' })
-  if (!spec.agents?.length) errors.push({ field: 'agents', message: 'At least one agent is required' })
-
-  for (const agent of spec.agents ?? []) {
-    const prefix = `agents.${agent.slug}`
-
-    if (!agent.slug?.trim()) errors.push({ field: prefix, message: 'Agent slug is required' })
-    if (!agent.name?.trim()) errors.push({ field: `${prefix}.name`, message: 'Agent name is required' })
-
-    if (!agent.models || agent.models.length === 0) {
-      errors.push({ field: `${prefix}.models`, message: 'At least one model is required' })
-    }
-  }
-
-  return { valid: errors.length === 0, errors }
-}
+export { validateTeamSpec } from '../../shared/validateTeamSpec'

--- a/src/renderer/src/components/SpecJsonPanel.tsx
+++ b/src/renderer/src/components/SpecJsonPanel.tsx
@@ -1,5 +1,10 @@
-import { useTeam } from '../hooks/useTeams'
+import { useState } from 'react'
+import { Pencil, X, Check } from 'lucide-react'
+import { useTeam, useSaveTeam } from '../hooks/useTeams'
 import { highlightContent } from '../lib/highlight'
+import { validateTeamSpec } from '../../../shared/validateTeamSpec'
+import { validateJsonEdit } from '../../../shared/validateJsonEdit'
+import type { TeamSpec } from '../../../shared/types'
 
 export function SpecJsonPanel({
   teamSlug,
@@ -9,6 +14,10 @@ export function SpecJsonPanel({
   agentSlug?: string
 }) {
   const { data: spec } = useTeam(teamSlug)
+  const saveTeam = useSaveTeam()
+  const [editing, setEditing] = useState(false)
+  const [editText, setEditText] = useState('')
+  const [errors, setErrors] = useState<string[]>([])
 
   if (!spec) {
     return (
@@ -31,12 +40,119 @@ export function SpecJsonPanel({
   }
 
   const json = JSON.stringify(data, null, 2)
+  const isTeamLevel = !agentSlug
+
+  const handleEdit = () => {
+    setEditText(json)
+    setErrors([])
+    setEditing(true)
+  }
+
+  const handleCancel = () => {
+    setEditing(false)
+    setErrors([])
+  }
+
+  const handleSave = () => {
+    const errs: string[] = []
+
+    let parsed: TeamSpec
+    try {
+      parsed = JSON.parse(editText)
+    } catch (e) {
+      setErrors([`Invalid JSON: ${(e as Error).message}`])
+      return
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      setErrors(['JSON must be an object'])
+      return
+    }
+
+    const structResult = validateTeamSpec(parsed)
+    if (!structResult.valid) {
+      errs.push(...structResult.errors.map((e) => `${e.field}: ${e.message}`))
+    }
+
+    const editResult = validateJsonEdit(spec, parsed)
+    if (!editResult.valid) {
+      errs.push(...editResult.errors)
+    }
+
+    if (errs.length > 0) {
+      setErrors(errs)
+      return
+    }
+
+    saveTeam.mutate(parsed, {
+      onSuccess: () => {
+        setEditing(false)
+        setErrors([])
+      },
+      onError: (err) => {
+        setErrors([`Save failed: ${(err as Error).message}`])
+      },
+    })
+  }
 
   return (
-    <div className="flex-1 overflow-auto p-6">
-      <pre className="text-xs font-mono text-gray-700 whitespace-pre-wrap break-words max-w-3xl">
-        {highlightContent(json, 'spec.json')}
-      </pre>
+    <div className="flex-1 overflow-hidden flex flex-col">
+      <div className="flex items-center justify-end gap-2 px-6 pt-4 pb-2 shrink-0">
+        {editing ? (
+          <>
+            <button
+              onClick={handleCancel}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+            >
+              <X className="h-3.5 w-3.5" />
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saveTeam.isPending}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-gray-900 hover:bg-gray-800 rounded-md transition-colors disabled:opacity-50"
+            >
+              <Check className="h-3.5 w-3.5" />
+              {saveTeam.isPending ? 'Saving...' : 'Save'}
+            </button>
+          </>
+        ) : (
+          isTeamLevel && (
+            <button
+              onClick={handleEdit}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              Edit
+            </button>
+          )
+        )}
+      </div>
+
+      {errors.length > 0 && (
+        <div className="mx-6 mb-2 p-3 bg-red-50 border border-red-200 rounded-md shrink-0">
+          {errors.map((err, i) => (
+            <p key={i} className="text-xs text-red-700">
+              {err}
+            </p>
+          ))}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-auto px-6 pb-6">
+        {editing ? (
+          <textarea
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
+            spellCheck={false}
+            className="w-full h-full text-xs font-mono text-gray-700 bg-gray-50 border border-gray-200 rounded-md p-4 resize-none focus:outline-none focus:ring-2 focus:ring-gray-300 max-w-3xl"
+          />
+        ) : (
+          <pre className="text-xs font-mono text-gray-700 whitespace-pre-wrap break-words max-w-3xl">
+            {highlightContent(json, 'spec.json')}
+          </pre>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/shared/validateJsonEdit.ts
+++ b/src/shared/validateJsonEdit.ts
@@ -1,0 +1,27 @@
+import type { TeamSpec } from './types'
+
+export function validateJsonEdit(
+  oldSpec: TeamSpec,
+  newSpec: TeamSpec
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = []
+
+  if (newSpec.slug !== oldSpec.slug) {
+    errors.push(`Team slug cannot be changed (was "${oldSpec.slug}", got "${newSpec.slug}")`)
+  }
+
+  if (newSpec.deployedEnvSlug !== oldSpec.deployedEnvSlug) {
+    errors.push(`deployedEnvSlug cannot be changed`)
+  }
+
+  const oldSlugs = new Set(oldSpec.agents.map((a) => a.slug))
+  const newAgentsBySlug = new Map(newSpec.agents.map((a) => [a.slug, a]))
+
+  for (const oldAgent of oldSpec.agents) {
+    if (!newAgentsBySlug.has(oldAgent.slug)) {
+      errors.push(`Agent slug "${oldAgent.slug}" cannot be removed or renamed`)
+    }
+  }
+
+  return { valid: errors.length === 0, errors }
+}

--- a/src/shared/validateTeamSpec.ts
+++ b/src/shared/validateTeamSpec.ts
@@ -1,0 +1,24 @@
+import { TeamSpec, ValidationResult, ValidationError } from './types'
+
+export const validateTeamSpec = (
+  spec: TeamSpec
+): ValidationResult => {
+  const errors: ValidationError[] = []
+
+  if (!spec.name?.trim()) errors.push({ field: 'name', message: 'Team name is required' })
+  if (!spec.slug?.trim()) errors.push({ field: 'slug', message: 'Team slug is required' })
+  if (!spec.agents?.length) errors.push({ field: 'agents', message: 'At least one agent is required' })
+
+  for (const agent of spec.agents ?? []) {
+    const prefix = `agents.${agent.slug}`
+
+    if (!agent.slug?.trim()) errors.push({ field: prefix, message: 'Agent slug is required' })
+    if (!agent.name?.trim()) errors.push({ field: `${prefix}.name`, message: 'Agent name is required' })
+
+    if (!agent.models || agent.models.length === 0) {
+      errors.push({ field: `${prefix}.models`, message: 'At least one model is required' })
+    }
+  }
+
+  return { valid: errors.length === 0, errors }
+}


### PR DESCRIPTION
Add editable textarea mode to SpecJsonPanel with validation to prevent modification of immutable fields (team slug, agent slugs, deployedEnvSlug).

- Toggle edit mode to replace read-only JSON with editable textarea
- Validate JSON syntax, required fields, and slug immutability on save
- Show inline error messages for validation failures
- Move validateTeamSpec to shared/ for renderer access
- Edit button only available at team level