### PR TITLE
feat: allow per-agent OpenRouter API key override

### DIFF
--- a/src/main/ipc/deploy.ts
+++ b/src/main/ipc/deploy.ts
@@ -32,19 +32,23 @@ export function registerDeployHandlers(): void {
       throw new Error(formatValidationFailure('Team spec validation failed', specValidation.errors))
     }
 
-    const telegramTokens = Object.fromEntries(await Promise.all(
-      spec.agents.map(async (agent) => {
+    const [telegramTokens, agentOpenRouterKeys] = await Promise.all([
+      Promise.all(spec.agents.map(async (agent) => {
         const token = await getSecret(telegramAccount(spec.slug, agent.slug), 'agent-telegram-token')
         return [agent.slug, token ?? undefined] as const
-      })
-    ))
+      })).then(Object.fromEntries),
+      Promise.all(spec.agents.map(async (agent) => {
+        const key = await getSecret(telegramAccount(spec.slug, agent.slug), 'agent-openrouter-key')
+        return [agent.slug, key ?? undefined] as const
+      })).then(Object.fromEntries),
+    ])
 
     const emailPassword = spec.teamEmail
       ? (await getSecret(`team:${teamSlug}`, 'team-email-password')) ?? undefined
       : undefined
 
     const deriver = getDeriver(env.type)
-    const specFiles = await deriver.derive(spec, env.config, { agentTelegramTokens: telegramTokens, teamEmailPassword: emailPassword })
+    const specFiles = await deriver.derive(spec, env.config, { agentTelegramTokens: telegramTokens, agentOpenRouterKeys, teamEmailPassword: emailPassword })
     const deployValidation = validateDerivedSpecFiles(specFiles)
     if (!deployValidation.valid) {
       throw new Error(formatValidationFailure('Deployment file validation failed', deployValidation.errors))

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -28,6 +28,7 @@ export function registerTeamHandlers(): void {
     const spec = await getTeam(slug)
     for (const agent of spec?.agents ?? []) {
       await deleteSecret(telegramAccount(slug, agent.slug), 'agent-telegram-token')
+      await deleteSecret(telegramAccount(slug, agent.slug), 'agent-openrouter-key')
     }
     await deleteSecret(`team:${slug}`, 'team-github-token')
     await deleteSecret(`team:${slug}`, 'team-openrouter-key')
@@ -60,6 +61,22 @@ export function registerTeamHandlers(): void {
         )
       }
     }
+    return { ok: true, cleared: false }
+  })
+
+  ipcMain.handle('teams:getAgentOpenRouterKeyMasked', async (_e, data: { teamSlug: string; agentSlug: string }) => {
+    const key = await getSecret(telegramAccount(data.teamSlug, data.agentSlug), 'agent-openrouter-key')
+    if (!key) return null
+    return key.length > 10 ? `${key.slice(0, 4)}••••${key.slice(-4)}` : '••••••••'
+  })
+
+  ipcMain.handle('teams:setAgentOpenRouterKey', async (_e, data: { teamSlug: string; agentSlug: string; key?: string }) => {
+    const key = data.key?.trim()
+    if (!key) {
+      await deleteSecret(telegramAccount(data.teamSlug, data.agentSlug), 'agent-openrouter-key')
+      return { ok: true, cleared: true }
+    }
+    await setSecret(telegramAccount(data.teamSlug, data.agentSlug), 'agent-openrouter-key', key)
     return { ok: true, cleared: false }
   })
 

--- a/src/main/specs/base.ts
+++ b/src/main/specs/base.ts
@@ -4,6 +4,7 @@ import { TeamSpec, SpecFile } from '../../shared/types'
 
 export interface DeriveSecrets {
   agentTelegramTokens?: Record<string, string | undefined>
+  agentOpenRouterKeys?: Record<string, string | undefined>
   teamEmailPassword?: string
 }
 

--- a/src/main/specs/gke.ts
+++ b/src/main/specs/gke.ts
@@ -171,7 +171,8 @@ const gkeDeriver: DeploymentSpecDeriver = {
       const effectiveEmail = agent.email || derivedEmail
       const models = agent.models.length > 0 ? agent.models : ['anthropic/claude-sonnet-4-6']
       const openclawConfig = openrouterToOpenClawJson(models)
-      const envVars = openrouterToEnvVars(openrouterApiKey)
+      const effectiveApiKey = secrets?.agentOpenRouterKeys?.[agent.slug] || openrouterApiKey
+      const envVars = openrouterToEnvVars(effectiveApiKey)
 
       const agentToken = teamGatewayToken
       const telegramBot = agent.telegramBot?.trim()

--- a/src/renderer/src/components/team/AgentCard.tsx
+++ b/src/renderer/src/components/team/AgentCard.tsx
@@ -36,6 +36,10 @@ export function AgentCard({
   const [tokenMasked, setTokenMasked] = useState<string | null>(null)
   const [tokenBusy, setTokenBusy] = useState(false)
   const [tokenError, setTokenError] = useState<string | null>(null)
+  const [orKey, setOrKey] = useState('')
+  const [orKeyMasked, setOrKeyMasked] = useState<string | null>(null)
+  const [orKeyBusy, setOrKeyBusy] = useState(false)
+  const [orKeyError, setOrKeyError] = useState<string | null>(null)
   const set = (key: keyof AgentSpec) => (value: unknown) =>
     onChange({ ...agent, [key]: value })
 
@@ -76,6 +80,15 @@ export function AgentCard({
       .catch((e) => {
         if (active) setTokenError((e as Error).message)
       })
+    window.api
+      .invoke('teams:getAgentOpenRouterKeyMasked', {
+        teamSlug,
+        agentSlug: agent.slug,
+      })
+      .then((value) => {
+        if (active) setOrKeyMasked((value as string | null) ?? null)
+      })
+      .catch(() => { /* non-fatal */ })
     return () => {
       active = false
     }
@@ -133,6 +146,46 @@ export function AgentCard({
       setTokenError((e as Error).message)
     } finally {
       setTokenBusy(false)
+    }
+  }
+
+  const saveOrKey = async () => {
+    setOrKeyBusy(true)
+    setOrKeyError(null)
+    try {
+      await window.api.invoke('teams:setAgentOpenRouterKey', {
+        teamSlug,
+        agentSlug: agent.slug,
+        key: orKey,
+      })
+      const masked = (await window.api.invoke(
+        'teams:getAgentOpenRouterKeyMasked',
+        { teamSlug, agentSlug: agent.slug },
+      )) as string | null
+      setOrKeyMasked(masked)
+      setOrKey('')
+    } catch (e) {
+      setOrKeyError((e as Error).message)
+    } finally {
+      setOrKeyBusy(false)
+    }
+  }
+
+  const clearOrKey = async () => {
+    setOrKeyBusy(true)
+    setOrKeyError(null)
+    try {
+      await window.api.invoke('teams:setAgentOpenRouterKey', {
+        teamSlug,
+        agentSlug: agent.slug,
+        key: '',
+      })
+      setOrKeyMasked(null)
+      setOrKey('')
+    } catch (e) {
+      setOrKeyError((e as Error).message)
+    } finally {
+      setOrKeyBusy(false)
     }
   }
 
@@ -240,6 +293,46 @@ export function AgentCard({
                 >
                   + Add model
                 </Button>
+              </div>
+              <div className="mt-3">
+                <Label>API Key override <Tooltip content="Overrides the team-level OpenRouter key for this agent only. Useful for per-agent billing tracking."><span className="text-gray-300 cursor-help">ⓘ</span></Tooltip></Label>
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5">
+                    <Input
+                      mono
+                      type="password"
+                      value={orKey}
+                      onChange={(e) => setOrKey(e.target.value)}
+                      placeholder={orKeyMasked ? 'Update key' : 'sk-or-...'}
+                    />
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      onClick={saveOrKey}
+                      disabled={orKeyBusy || !teamSlug || !agent.slug}
+                      className="shrink-0"
+                    >
+                      Save
+                    </Button>
+                  </div>
+                  {orKeyMasked && (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={clearOrKey}
+                      disabled={orKeyBusy}
+                      className="shrink-0"
+                    >
+                      Clear
+                    </Button>
+                  )}
+                </div>
+                {orKeyMasked && (
+                  <p className="text-xs text-gray-400 font-mono mt-0.5">{orKeyMasked}</p>
+                )}
+                {orKeyError && (
+                  <p className="text-xs text-red-600 mt-0.5">{orKeyError}</p>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

Add support for agents to override the team-level OpenRouter API key with their own credentials for per-agent billing tracking and independent quota management.

## Changes

- Add `agentOpenRouterKeys` to `DeriveSecrets` interface for passing per-agent keys through deployment derivers
- Add IPC handlers `teams:getAgentOpenRouterKeyMasked` and `teams:setAgentOpenRouterKey` for keychain management (using `team:slug:agent:slug` namespace)
- Collect per-agent OpenRouter keys in deploy handler (parallel with telegram tokens) and pass to deriver
- Use per-agent key as override in gke deriver: `secrets?.agentOpenRouterKeys?.[agent.slug] || teamKey`
- Add UI in AgentCard under "OpenRouter Models" section with password input, Save, and Clear buttons matching the Telegram token pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)