### PR TITLE
fix: expose port 19876 for all D Squad agents

### DIFF
--- a/data/teams/team-d-squad.json
+++ b/data/teams/team-d-squad.json
@@ -14,7 +14,15 @@
       "email": "dsquad@ai.taiko.xyz",
       "skills": [],
       "persona": "Autonomous workflow pipeline manager and quality orchestrator",
-      "models": ["openrouter/minimax/minimax-m2.5"]
+      "models": ["openrouter/minimax/minimax-m2.5"],
+      "additionalPorts": [
+        {
+          "port": 19876,
+          "targetPort": 19876,
+          "name": "project-api",
+          "protocol": "TCP"
+        }
+      ]
     },
     {
       "slug": "bob-li",
@@ -44,7 +52,15 @@
       "email": "dsquad+ripley@ai.taiko.xyz",
       "skills": [],
       "persona": "Premium web experience developer using Laravel, Livewire, and FluxUI",
-      "models": ["openrouter/minimax/minimax-m2.5"]
+      "models": ["openrouter/minimax/minimax-m2.5"],
+      "additionalPorts": [
+        {
+          "port": 19876,
+          "targetPort": 19876,
+          "name": "project-api",
+          "protocol": "TCP"
+        }
+      ]
     },
     {
       "slug": "aeryn",
@@ -55,7 +71,15 @@
       "email": "dsquad+aeryn@ai.taiko.xyz",
       "skills": [],
       "persona": "Real-time engagement specialist for Twitter and professional platforms",
-      "models": ["openrouter/minimax/minimax-m2.5"]
+      "models": ["openrouter/minimax/minimax-m2.5"],
+      "additionalPorts": [
+        {
+          "port": 19876,
+          "targetPort": 19876,
+          "name": "project-api",
+          "protocol": "TCP"
+        }
+      ]
     },
     {
       "slug": "deckard",
@@ -66,7 +90,15 @@
       "email": "dsquad+deckard@ai.taiko.xyz",
       "skills": [],
       "persona": "Expert market intelligence analyst specializing in identifying emerging trends",
-      "models": ["openrouter/minimax/minimax-m2.5"]
+      "models": ["openrouter/minimax/minimax-m2.5"],
+      "additionalPorts": [
+        {
+          "port": 19876,
+          "targetPort": 19876,
+          "name": "project-api",
+          "protocol": "TCP"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds additionalPorts configuration (19876/TCP for project-api) to all D Squad agents:
- alice-wong
- ripley  
- aeryn
- deckard

Bob-li already had this configuration. This enables the live dashboard integration to reach the Project API running on each agent.

## Testing

- [ ] Verify port 19876 is exposed on all agent services
- [ ] Confirm dashboard can reach Project API on each agent

## Related

- Blocks live dashboard integration for D Squad
- Follow-up to PR #172 (which has other unrelated changes)