### PR TITLE
fix: add packages field to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 ignoredBuiltDependencies:
   - electron
   - electron-winstaller


### PR DESCRIPTION
The pnpm-workspace.yaml was missing the required 'packages' field, causing 'pnpm install' to fail. Added packages entry pointing to the root package to resolve the issue.