### PR TITLE
fix: correct useEffect deps and remove duplicate rule

### DIFF
--- a/src/renderer/src/components/DeployPanel.tsx
+++ b/src/renderer/src/components/DeployPanel.tsx
@@ -47,7 +47,7 @@ export function DeployPanel({
   const isAnyDeploying = !!deployingTeamSlug;
   const isThisDeploying = deployingTeamSlug === teamSlug;
   const { data: deployReadiness } = useQuery<DeployReadinessResult>({
-    queryKey: ["deploy:readiness", teamSlug, agentSlug, spec],
+    queryKey: ["deploy:readiness", teamSlug, agentSlug, spec?.slug],
     queryFn: () =>
       window.api.invoke("deploy:getReadiness", {
         teamSlug,
@@ -85,7 +85,7 @@ export function DeployPanel({
         if (loaded.length > 0) setLogEntries(loaded);
       })
       .catch(() => {});
-  }, [spec]);
+  }, [spec?.slug]);
 
   useEffect(() => {
     return window.api.on?.("deploy:status", (data: unknown) => {
@@ -109,7 +109,7 @@ export function DeployPanel({
         .invoke("deploy:saveLogs", { teamSlug: spec.slug, entries: logEntries })
         .catch(() => {});
     }
-  }, [deployState, logEntries, spec]);
+  }, [deployState, logEntries, spec?.slug]);
 
   const handleDeploy = useCallback(
     async (deployAgentSlug?: string) => {

--- a/src/shared/derivationDefaults.ts
+++ b/src/shared/derivationDefaults.ts
@@ -42,7 +42,6 @@ export const DEFAULT_TEAM_LEAD_RESPONSIBILITIES: string[] = [
 
 export const DEFAULT_RULES: string[] = [
   'Always verify your understanding before executing complex tasks',
-  'You are the orchestrator. never do work yourself. spawn subagents for every task. your job is to think, plan & coordinate. subagents execute.',
 ]
 
 export const DEFAULT_USER_INTRO: string[] = [


### PR DESCRIPTION
## Summary
- Fixed DeployPanel useEffect dependencies to use stable `spec?.slug` instead of unstable `spec` object reference, preventing unnecessary re-fires on react-query background refetches
- Removed duplicate orchestrator rule from DEFAULT_RULES (already present in DEFAULT_TEAM_LEAD_RESPONSIBILITIES with proper isLead gating)

## Test Plan
- [ ] Deploy panel loads without excessive log IPC calls
- [ ] All agents receive appropriate default rules (lead gets orchestrator rule, workers don't)