### PR TITLE
docs: Knowledge distillation — dashboard architecture, GitHub workflow, web dev onboarding

### DIFF
--- a/specs/dashboard-architecture.md
+++ b/specs/dashboard-architecture.md
@@ -1,0 +1,122 @@
+# D Squad Coordination Dashboard — Architecture
+
+> **Repo:** dsquadteam/dsquad-dashboard  
+> **Branch:** `d-squad`  
+> **Stack:** Laravel 11 + Livewire 3 + FluxUI + Alpine.js  
+> **Author:** Agent Ripley@team-d-squad
+
+---
+
+## Overview
+
+Real-time coordination dashboard for D Squad agent management. Shows task kanban boards, project management, agent status cards, collaboration health metrics, and budget tracking.
+
+## API Architecture — Primary→Fallback
+
+The dashboard uses a **permanently dual-source** API architecture:
+
+1. **Primary:** Bob Li's Project Management API at `http://agent-bob-li.team-d-squad.svc.cluster.local:19876`
+2. **Fallback:** Local `MockDataService` (PHP) with realistic test data
+
+`DashboardApiClient` tries the primary endpoint first. On connection failure/timeout, it falls back to MockDataService automatically. This is NOT temporary — mock data is the permanent development/test fallback.
+
+### Bob's API URL Format (Important)
+Bob's API uses **mixed URL patterns**:
+- Projects: `/api/teams/team-d-squad/projects`
+- Tasks, Agents, Events: `/api/v1/tasks`, `/api/v1/agents`, `/api/v1/events`
+- Health: `/health`
+
+### Port 19876 Cross-Pod Access
+- Bob's API runs on port 19876 inside his pod
+- K8s Service `project-api` (ClusterIP) exposes this — see `specs/project-api.yaml`
+- The `additionalPorts` configuration in `team-d-squad.json` declares `{containerPort: 19876, name: "project-api"}`
+- Requires Daniel to deploy from Coordina desktop app for changes to take effect
+
+## SSE (Server-Sent Events) — Event Notation
+
+**Critical alignment issue discovered and fixed:**
+
+| Component | Notation | Example |
+|-----------|----------|---------|
+| Bob's API server | DOT | `task.created`, `agent.status_changed` |
+| Local mock server (`server.cjs`) | COLON | `task:created`, `agent:status_changed` |
+| Browser EventSource API | DOT (matches Bob) | Must use DOT for `.addEventListener()` |
+| Alpine.js dispatch | DOT | `$dispatch('task.created', data)` |
+
+**The sse-client.js must use DOT notation** to match Bob's actual SSE output. The local server.cjs uses COLON notation for development, but the SSE proxy route (`/sse/events`) forwards to Bob's primary endpoint first.
+
+### SSE Events Emitted by Bob
+- `task.created`, `task.updated`, `task.deleted`
+- `agent.status_changed`
+- `project.created`, `project.updated`
+- `message.sent`, `token.usage` (health panel events)
+- `heartbeat` (every 15s)
+- `connected` (on initial connection)
+
+**Note:** Bob does NOT emit `project.deleted` events.
+
+### SSE Proxy Route
+Laravel route at `/sse/events` acts as a proxy:
+1. Try: `http://agent-bob-li...:19876/api/v1/events`
+2. Fallback: Local mock SSE stream
+
+### Smart Polling Pattern
+Livewire components use adaptive polling:
+- SSE connected → slow polling (60s fallback)
+- SSE disconnected → fast polling (10-15s)
+- Cache TTL reduced to 5s for SSE responsiveness
+
+## Task Status Values
+
+**Canonical status values** (aligned across all components):
+
+| Status | Description |
+|--------|-------------|
+| `unclaimed` | No assignee |
+| `in_progress` | Being worked on |
+| `on_hold` | Paused/blocked |
+| `completed` | Done |
+
+**NOT used:** `review`, `done` — these were in early mocks but removed for consistency.
+
+Status alignment must match in: Livewire validation rules, Kanban column keys, Blade color maps, MockDataService, and Bob's API.
+
+## Key Components
+
+### Pages
+- **TaskKanban** — Drag-and-drop kanban board (unclaimed → in_progress → on_hold → completed)
+- **TaskList** — Table view with search/filter
+- **ProjectOverview** — Project cards with CRUD modals
+- **DashboardStats** — Summary metrics
+- **AgentStatusCards** — Real-time agent status grid
+
+### Health Panel (Issue #156)
+- **AgentHealthGrid** — Agent health status (30s poll)
+- **CommunicationMatrix** — Inter-agent message flow (60s poll)
+- **BudgetMeter** — Token budget tracking (5min poll)
+- **AlertFeed** — System alerts with severity filter (30s poll)
+
+### Bob's Health Panel API Endpoints
+| Endpoint | Method | Response Shape |
+|----------|--------|---------------|
+| `/api/v1/messages` | GET | `{messages: [...], count, total}` — uses `message` field not `content`, no senderName/recipientName |
+| `/api/v1/token-usage` | GET | `{usage: [...], count, total, summary}` |
+| `/api/v1/token-usage/summary` | GET | `{total, byAgent, byModel}` — uses `period` param |
+| `/api/v1/budget` | GET/PATCH | Budget configuration |
+| `/api/v1/budget/status` | GET | `{configured, usage, alert}` — NO per-agent/per-model breakdown (get from summary) |
+
+### Reusable Blade Components
+- `x-skeleton-card`, `x-skeleton-line`, `x-skeleton-circle` — Loading states
+- `x-empty-state` — Consistent empty view
+- `x-error-panel` — Error with retry button
+
+## Branch Strategy
+- All dashboard work targets `d-squad` branch
+- Feature branches: `feat/<description>` or `feature/<issue>-<description>`
+- PRs target `d-squad`, Daniel merges `d-squad` → `main`
+
+## Open PRs (dsquadteam/dsquad-dashboard)
+- PR #6: Health Panel (Phase 1-2)
+- PR #9: Kanban enhancements
+- PR #13: SSE Livewire wiring
+- PR #18: UX Polish (Issue #5)

--- a/specs/github-workflow.md
+++ b/specs/github-workflow.md
@@ -1,0 +1,38 @@
+# D Squad GitHub Workflow
+
+> **Effective:** 2026-03-11  
+> **Source:** Daniel (team admin) via Telegram
+
+---
+
+## Repositories
+
+| Repo | Purpose | Branch Strategy |
+|------|---------|-----------------|
+| `taikoxyz/Coordina` | Coordina desktop app + team infrastructure | `d-squad` branch for team work; Daniel merges to `main` |
+| `dsquadteam/dsquad-dashboard` | D Squad coordination dashboard | `d-squad` branch; same model |
+
+## Autonomy Rules
+- **Full autonomy**: Create PRs, file issues without asking Daniel first
+- **Peer reviews**: Done internally (agent-to-agent)
+- **Merge authority**: Agents can approve and merge PRs themselves
+- **Branch target**: ALL changes go into `d-squad` branch, NOT `main`
+- **Final merge**: Daniel does `d-squad` → `main` when ready
+
+## Shared Account Limitation
+All agents share the `dsquadteam` GitHub account. This means:
+- You CANNOT formally approve your own PRs (GitHub blocks self-approval)
+- Use COMMENT reviews with explicit "APPROVED" markers as workaround
+- Always identify yourself: "Agent [Name]@team-d-squad" in PR descriptions and comments
+- Coordinate before force-pushing or deleting branches
+
+## PR Review Requirements
+- **Regular PRs**: Standard peer review (1+ teammate)
+- **Markdown distillation PRs** (touching AGENTS.md, SOUL.md, TOOLS.md, BOOTSTRAP.md, IDENTITY.md, SKILLS.md, HEARTBEAT.md): **ALL 4 teammates** must approve before merge
+- Leave substantive comments on distillation PRs: "Does this give a fresh agent everything they need?"
+- Link related issues: `Closes #168` or `Relates to #123`
+
+## Commit Conventions
+- Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`
+- Include issue references: `feat(#156): add health panel components`
+- Squash-merge preferred for clean history

--- a/specs/web-dev-knowledge-distillation.md
+++ b/specs/web-dev-knowledge-distillation.md
@@ -1,0 +1,68 @@
+# Knowledge Distillation — Web Dev Agent (Ripley-Equivalent)
+
+> **Purpose:** What BOOTSTRAP.md and SOUL.md should include for a freshly deployed web development agent  
+> **Author:** Agent Ripley@team-d-squad  
+> **Context:** Assignment from Alice Wong, 2026-03-11
+
+---
+
+## What a Fresh Ripley Needs on Day 1
+
+### 1. Repo Locations and Branch Rules
+- Dashboard repo: `dsquadteam/dsquad-dashboard`, branch `d-squad`
+- Coordina repo: `taikoxyz/Coordina`, branch `d-squad`
+- NEVER push to `main` — Daniel controls that merge
+- See `specs/github-workflow.md` for full policy
+
+### 2. Stack Knowledge
+- **Laravel 11** — PHP framework, routes in `routes/web.php`
+- **Livewire 3** — Server-driven reactive components in `app/Livewire/`
+- **FluxUI** — Premium Blade component library (modals, forms, buttons)
+- **Alpine.js** — Client-side interactivity, listens for SSE-dispatched events
+- **Tailwind CSS** — Utility-first CSS with dark theme support
+
+### 3. Dashboard Architecture
+- Read `specs/dashboard-architecture.md` for the primary→fallback API pattern
+- The mock data layer is PERMANENT (not temporary) — it's the dev/test fallback
+- Bob's API is the primary data source when cross-pod connectivity works
+- SSE uses DOT notation — this was a hard-won lesson, don't switch back to COLON
+
+### 4. Critical Gotchas (Lessons Learned)
+1. **SSE event notation**: Bob's server emits DOT (`task.created`), not COLON (`task:created`). EventSource `.addEventListener()` must use DOT.
+2. **Status enum alignment**: Use `unclaimed`, `in_progress`, `on_hold`, `completed` everywhere. NOT `review`/`done`.
+3. **Port 19876 cross-pod**: Requires K8s Service + Coordina redeploy. Check `specs/project-api.yaml`.
+4. **Shared GitHub account**: Can't self-approve PRs. Use COMMENT reviews with APPROVED marker.
+5. **Bob's response shapes differ from mock**: Messages use `message` not `content`, token-usage wraps in `{usage: [...]}`, budget/status has `{configured, usage, alert}` structure.
+6. **Orphaned HTML**: Watch for unclosed tags in Blade templates when components are refactored — causes hydration errors in Livewire.
+7. **Cache TTL**: Keep at 5s when SSE is active, not the default 15s.
+
+### 5. Bob's API Quirks
+- Mixed URL patterns (see architecture doc)
+- No `project.deleted` SSE event
+- `token-usage/summary` uses `period` query param, not windowed
+- `budget/status` has NO per-agent/per-model breakdown — cross-reference with `token-usage/summary`
+
+### 6. SOUL.md Essentials for Web Dev Agent
+```
+Creative, detail-oriented, and innovation-driven.
+Brings pattern recognition from many premium builds,
+knowing the difference between basic and luxury implementation.
+Remembers what works and avoids common pitfalls.
+
+Language Rules: Chinese or English with Daniel, English everywhere else.
+Orchestrator mindset: spawn subagents, don't do the work yourself.
+Repo is truth, memory is cache.
+```
+
+### 7. Tool Priorities
+- `gh` CLI for all GitHub operations (pre-authenticated)
+- `curl` for API testing and inter-agent communication
+- Subagents for any implementation work longer than a quick fix
+- Always test with mock data first, then verify against Bob's live API
+
+### 8. Who To Ask
+- **Alice Wong** (lead): Task assignments, priority decisions, escalations
+- **Bob Li**: API questions, SSE schema, backend data issues
+- **Aeryn**: Social media, external communications
+- **Deckard**: Market intelligence, config research
+- **Daniel**: Infrastructure, deploys, main branch merges


### PR DESCRIPTION
## Knowledge Distillation — Memory-Wipe Resilience

**Author:** Agent Ripley@team-d-squad  
**Assignment:** Assignment 4 from Alice Wong (2026-03-11)  
**Directive:** Daniel directed us to work assuming memory files may be wiped entirely. The repo is the only persistent truth.

---

### What this PR does

Extracts critical team knowledge that currently exists only in ephemeral agent memory into persistent repo documentation. A fresh agent deployed with zero memory should be able to read these specs and be productive on day 1.

### Files added

| File | Purpose |
|------|---------|
| `specs/dashboard-architecture.md` | Full D Squad coordination dashboard architecture — API dual-source pattern, SSE event notation (DOT vs COLON), task status enums, component inventory, Bob's API endpoints and response shapes |
| `specs/github-workflow.md` | Team GitHub workflow — repo locations, branch strategy, autonomy rules, shared account limitations, PR review requirements, commit conventions |
| `specs/web-dev-knowledge-distillation.md` | Day-1 onboarding guide for a web dev agent (Ripley-equivalent) — stack knowledge, critical gotchas, API quirks, tool priorities, team contacts |

### Why this matters

Without these docs in the repo, a memory wipe would lose:
- The SSE DOT vs COLON notation alignment (hard-won debugging lesson)
- Bob's mixed API URL patterns and response shape differences from mock
- Task status enum decisions (why `review`/`done` were removed)
- Port 19876 cross-pod access requirements
- Shared GitHub account workarounds
- Health panel API endpoint details

All of this is operational knowledge that took significant effort to discover and align.

### Review notes
- This is a **knowledge distillation PR** — please review for completeness: "Does this give a fresh agent everything they need?"
- Per team workflow, distillation PRs benefit from broad review