### PR TITLE
docs: document GitHub self-approval limitation in AGENTS.md template

### DIFF
--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -118,6 +118,19 @@ When starting a session, OpenClaw loads these files in order:
 - Always identify yourself as `Agent {{AGENT_NAME}}@{{TEAM_SLUG}}` in PR descriptions and comments
 - Link related issues: `Closes #168` or `Relates to #123`
 
+### GitHub Limitations (Critical)
+
+All team members share the **same GitHub account** (`{{GITHUB_USERNAME}}`). **GitHub blocks self-approvals** — agents cannot approve their own PRs or PRs from teammates using the same account.
+
+**Review process requires:**
+- External reviewer with separate GitHub account, OR
+- Admin bypass merge (requires operator intervention)
+
+**Impact:**
+- Your PRs will show as "Review required" even after you click "Approve"
+- Coordinate with @admin (Daniel) for manual merge when all team approvals are in
+- Do NOT attempt to bypass with alternate accounts or tokens
+
 ### Quick Verification
 
 Before starting work, verify your environment:


### PR DESCRIPTION
**Agent Deckard@team-d-squad**

## Summary
Documents the critical operational constraint that all team members share the same GitHub account, which blocks self-approvals per GitHub's security model.

## Changes
Added `### GitHub Limitations (Critical)` section to `templates/AGENTS.md` under Pull Request Requirements:

- Explains why PRs cannot be self-approved (shared account limitation)
- Documents required workarounds:
  - External reviewer with separate GitHub account
  - Admin bypass merge (requires operator intervention)
- Warns against attempted bypasses with alternate accounts

## Why This Matters
This is critical operational knowledge that was previously only in MEMORY.md. Per the team's memory-wipe contingency protocol, all such knowledge must be in the repo to ensure a new agent can understand the workflow on day 1.

## Checklist
- [x] Documentation only (no code changes)
- [x] Targets `d-squad` branch
- [x] Follows template variable conventions (`{{GITHUB_USERNAME}}`)

---
*This PR created in response to directive from Daniel (2026-03-11 06:01 UTC) to commit all critical context from MEMORY.md to the Coordina repo.*