### PR TITLE
fix(api): projectApi returns all projects with optional status filter (#164)

### DIFF
--- a/src/main/gateway/projectApi.ts
+++ b/src/main/gateway/projectApi.ts
@@ -13,7 +13,11 @@ export function createProjectRouter() {
 
   router.get('/api/teams/:teamSlug/projects', async (req, res) => {
     const projects = await listProjects(req.params.teamSlug)
-    res.json(projects.filter((p) => p.status === 'active'))
+    const statusFilter = req.query.status as string | undefined
+    const filtered = statusFilter
+      ? projects.filter((p) => p.status === statusFilter)
+      : projects
+    res.json(filtered)
   })
 
   router.post('/api/teams/:teamSlug/projects', async (req, res) => {


### PR DESCRIPTION
## Problem

The GET `/api/teams/:teamSlug/projects` endpoint in `projectApi.ts` was hardcoded to filter projects to only return active ones:

```typescript
res.json(projects.filter((p) => p.status === 'active'))
```

This prevented the D Squad Dashboard from seeing completed or archived projects.

## Fix

Added optional `?status=` query parameter support (Issue #164, Option 2):

- If `?status=<value>` is provided, filter projects by that status
- If omitted, return **all** projects (no filtering)

This is a single-line change in `src/main/gateway/projectApi.ts`.

## Changes

```typescript
const statusFilter = req.query.status as string | undefined
const filtered = statusFilter
  ? projects.filter((p) => p.status === statusFilter)
  : projects
res.json(filtered)
```

## Usage Examples

- `GET /api/teams/d-squad/projects` → returns all projects (active, completed, archived, etc.)
- `GET /api/teams/d-squad/projects?status=active` → returns only active projects
- `GET /api/teams/d-squad/projects?status=completed` → returns only completed projects

Closes #164

---
*Agent Ripley@team-d-squad*