### PR TITLE
feat: add team import from JSON spec files

### DIFF
--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -1,6 +1,7 @@
 // IPC handlers for team spec CRUD replacing SQLite with file-based storage
 // FEATURE: Team management IPC layer using ~/.coordina/teams/{slug}.json files
-import { ipcMain } from 'electron'
+import { ipcMain, dialog, BrowserWindow } from 'electron'
+import fs from 'fs/promises'
 import { listTeams, getTeam, saveTeam, deleteTeam } from '../store/teams'
 import { deleteTeamDeployment } from '../store/deployments'
 import { runPipeline } from '../watcher'
@@ -137,6 +138,39 @@ export function registerTeamHandlers(): void {
     if (!token) throw new Error('No Telegram token saved for this agent')
     await syncBotProfilePhoto(token, data.agentSlug, agentIndex)
     return { ok: true }
+  })
+
+  ipcMain.handle('teams:import', async (e) => {
+    const win = BrowserWindow.fromWebContents(e.sender) ?? undefined
+    const result = await dialog.showOpenDialog({
+      ...(win ? { parentWindow: win } : {}),
+      filters: [{ name: 'JSON', extensions: ['json'] }],
+      properties: ['openFile'],
+    })
+    if (result.canceled || !result.filePaths.length) return { ok: false, reason: 'cancelled' }
+
+    let raw: unknown
+    try {
+      const content = await fs.readFile(result.filePaths[0], 'utf-8')
+      raw = JSON.parse(content)
+    } catch {
+      return { ok: false, reason: 'File is not valid JSON' }
+    }
+
+    if (!raw || typeof raw !== 'object' || !('slug' in raw) || !('name' in raw) || !('agents' in raw)) {
+      return { ok: false, reason: 'File does not contain a valid team spec (missing slug, name, or agents)' }
+    }
+
+    const spec = raw as TeamSpec
+    const normalized = normalizeTeamSpec(spec)
+    const existing = await getTeam(normalized.slug)
+    if (existing) {
+      return { ok: false, reason: `Team with slug "${normalized.slug}" already exists` }
+    }
+
+    validateTelegramPair(normalized)
+    await saveTeam(normalized)
+    return { ok: true, slug: normalized.slug }
   })
 
   ipcMain.handle('teams:derive', async (_e, slug: string) => {

--- a/src/renderer/src/components/AppSidebar.tsx
+++ b/src/renderer/src/components/AppSidebar.tsx
@@ -1,7 +1,7 @@
-import { ChevronRight, ChevronDown, Crown, Loader2, Plus, Send, Settings } from 'lucide-react'
+import { ChevronRight, ChevronDown, Crown, Loader2, Plus, Send, Settings, Upload } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNav } from '../store/nav'
-import { useTeams, useSaveTeam } from '../hooks/useTeams'
+import { useTeams, useSaveTeam, useImportTeam } from '../hooks/useTeams'
 import { useSettings } from '../hooks/useSettings'
 import { cn } from '../lib/utils'
 import { AgentAvatar } from './AgentAvatar'
@@ -12,8 +12,18 @@ export function AppSidebar() {
   const { selectedItem, selectItem, expandedTeams, toggleTeam, openSettings, setCreateDialogOpen, deployingTeamSlug, deployingAgentSlug } = useNav()
   const { data: teams } = useTeams()
   const saveTeam = useSaveTeam()
+  const importTeam = useImportTeam()
   const queryClient = useQueryClient()
   const { data: settings } = useSettings()
+
+  const handleImportTeam = async () => {
+    const result = await importTeam.mutateAsync()
+    if (result.ok && result.slug) {
+      selectItem({ type: 'team', slug: result.slug })
+    } else if (result.reason && result.reason !== 'cancelled') {
+      alert(result.reason)
+    }
+  }
 
   const addAgent = async (teamSlug: string) => {
     const team = (teams ?? []).find((t) => t.slug === teamSlug)
@@ -145,12 +155,22 @@ export function AppSidebar() {
       </div>
 
       <div className="shrink-0 border-t border-gray-100 px-3 py-2 flex items-center justify-between">
-        <button
-          onClick={() => setCreateDialogOpen('teams')}
-          className="flex items-center gap-2 text-sm text-gray-500 transition-colors hover:text-gray-700"
-        >
-          Add team
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setCreateDialogOpen('teams')}
+            className="flex items-center gap-1 text-sm text-gray-500 transition-colors hover:text-gray-700"
+          >
+            Add team
+          </button>
+          <button
+            onClick={() => void handleImportTeam()}
+            className="flex items-center gap-1 text-sm text-gray-500 transition-colors hover:text-gray-700"
+            title="Import team from JSON file"
+          >
+            <Upload className="w-3.5 h-3.5" />
+            Import
+          </button>
+        </div>
         <button
           onClick={() => openSettings()}
           className={cn(

--- a/src/renderer/src/hooks/useTeams.ts
+++ b/src/renderer/src/hooks/useTeams.ts
@@ -30,6 +30,17 @@ export const useSaveTeam = () => {
   })
 }
 
+export const useImportTeam = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      window.api.invoke('teams:import') as Promise<{ ok: boolean; slug?: string; reason?: string }>,
+    onSuccess: (data) => {
+      if (data.ok) qc.invalidateQueries({ queryKey: ['teams'] })
+    },
+  })
+}
+
 export const useDeleteTeam = () => {
   const qc = useQueryClient()
   return useMutation({


### PR DESCRIPTION
## Summary
Adds an "Import team" feature that allows users to import a team's JSON spec file to create a new team. If the team slug already exists, displays an error message.

## Changes
- Add `teams:import` IPC handler with native file picker filtered to JSON files
- Validate imported spec has required fields (slug, name, agents)
- Check for slug collisions and return error if exists
- Add `useImportTeam` React hook with automatic cache invalidation
- Add "Import" button in sidebar footer with upload icon

## Testing
1. Click "Import" in sidebar
2. Select a valid team JSON file → team appears in sidebar and is automatically selected
3. Try importing a file with an existing slug → shows error alert
4. Try importing invalid JSON → shows error alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)