### PR TITLE
fix: delete agent ConfigMap and credentials Secret in undeployAgent

### DIFF
--- a/src/main/environments/gke/deploy.test.ts
+++ b/src/main/environments/gke/deploy.test.ts
@@ -298,6 +298,12 @@ describe('undeployAgent', () => {
     expect(mockListDisksByLabels).not.toHaveBeenCalled()
     expect(mockDeleteDisk).not.toHaveBeenCalled()
   })
+
+  it('always deletes ConfigMap and credentials Secret regardless of deleteDisks', async () => {
+    for await (const _ of undeployAgent('team', 'alice', config, { deleteDisks: false })) { /* drain */ }
+    expect(mockCoreApi.deleteNamespacedConfigMap).toHaveBeenCalledWith({ name: 'team-alice-config', namespace: 'team' })
+    expect(mockCoreApi.deleteNamespacedSecret).toHaveBeenCalledWith({ name: 'team-alice-credentials', namespace: 'team' })
+  })
 })
 
 describe('getTeamStatus', () => {

--- a/src/main/environments/gke/deploy.ts
+++ b/src/main/environments/gke/deploy.ts
@@ -392,6 +392,8 @@ export async function* undeployAgent(teamSlug: string, agentSlug: string, config
   for (const [label, fn] of [
     [`StatefulSet/${resourceName}`, () => appsApi.deleteNamespacedStatefulSet({ name: resourceName, namespace })],
     [`Service/${resourceName}`, () => coreApi.deleteNamespacedService({ name: resourceName, namespace })],
+    [`ConfigMap/${teamSlug}-${agentSlug}-config`, () => coreApi.deleteNamespacedConfigMap({ name: `${teamSlug}-${agentSlug}-config`, namespace })],
+    [`Secret/${teamSlug}-${agentSlug}-credentials`, () => coreApi.deleteNamespacedSecret({ name: `${teamSlug}-${agentSlug}-credentials`, namespace })],
   ] as [string, () => Promise<unknown>][]) {
     try { await fn(); yield { resource: label, status: 'deleted' } }
     catch { yield { resource: label, status: 'error' } }


### PR DESCRIPTION
Aligns `undeployAgent` cleanup with `deployTeam` behavior by always deleting an agent's ConfigMap and credentials Secret when the agent is undeployed or removed from team spec. This prevents accumulation of stale configuration and credential resources. PVC/disk cleanup remains gated on the `deleteDisks` option for data safety.

Fixes the resource leak where ConfigMap and Secret were orphaned when agents were individually undeployed.